### PR TITLE
Properly use inode_offset while still unsigned

### DIFF
--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -478,7 +478,7 @@ impl Squashfs {
             for d in &dirs {
                 trace!("extracing entry: {:#?}", d.dir_entries);
                 for entry in &d.dir_entries {
-                    let inode_key = d.inode_num + entry.inode_offset as u32;
+                    let inode_key = (d.inode_num as i16 + entry.inode_offset) as u32;
                     trace!("extracing inode: {inode_key}");
                     let found_inode = &self.inodes[&inode_key];
                     trace!("extracing inode: {found_inode:?}");


### PR DESCRIPTION
* Avoid overflow when calculating the inode offset from start offset