### PR TITLE
Represent files with a Reader instead of Bytes

### DIFF
--- a/src/bin/unsquashfs.rs
+++ b/src/bin/unsquashfs.rs
@@ -70,11 +70,15 @@ fn extract_all(input: &Path, offset: u64, output: &Path) {
     for node in filesystem.nodes {
         let path = node.path;
         match node.inner {
-            InnerNode::File(SquashfsFile { bytes, .. }) => {
+            InnerNode::File(SquashfsFile { reader, .. }) => {
                 let path: PathBuf = path.iter().skip(1).collect();
                 tracing::debug!("file {}", path.display());
                 let filepath = Path::new(output).join(path);
                 let _ = std::fs::create_dir_all(filepath.parent().unwrap());
+                //TODO use the reader instead of the reading bytes to memory
+                let mut bytes = vec![];
+                let mut reader = reader.borrow_mut();
+                reader.read_to_end(&mut bytes).unwrap();
                 match std::fs::write(&filepath, bytes) {
                     Ok(_) => println!("[-] success, wrote {}", filepath.display()),
                     Err(e) => {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,10 +1,11 @@
 //! File Data
 
-use std::io::Write;
+use std::io::{SeekFrom, Write};
 
 use tracing::instrument;
 
 use crate::compressor::{compress, CompressionOptions, Compressor};
+use crate::filesystem::SquashfsFileReader;
 use crate::fragment::Fragment;
 
 pub(crate) enum Added {
@@ -53,12 +54,16 @@ impl DataWriter {
 
     /// Add to data writer, either a Data or Fragment
     // TODO: support tail-end fragments (off by default in squashfs-tools/mksquashfs)
-    pub(crate) fn add_bytes(&mut self, bytes: &[u8]) -> Added {
-        let mut chunks = bytes.chunks(self.block_size as usize);
+    pub(crate) fn add_bytes(&mut self, reader: &mut dyn SquashfsFileReader) -> Added {
+        //go to the end, calculating the file len
+        let len = reader.seek(SeekFrom::End(0)).unwrap();
+        //go back to the start
+        reader.seek(SeekFrom::Start(0)).unwrap();
 
         // only one chunks, and not exactly the size of the block
-        if chunks.len() == 1 && bytes.len() != self.block_size as usize {
-            let chunk = chunks.next().unwrap();
+        if len < self.block_size.into() {
+            let mut chunk = vec![0u8; len as usize];
+            reader.read_exact(&mut chunk).unwrap();
 
             // if this doesn't fit in the current fragment bytes, compress and add to data_bytes
             if (chunk.len() + self.fragment_bytes.len()) > self.block_size as usize {
@@ -85,7 +90,7 @@ impl DataWriter {
             // add to fragment bytes
             let frag_index = self.fragment_table.len() as u32;
             let block_offset = self.fragment_bytes.len() as u32;
-            self.fragment_bytes.write_all(chunk).unwrap();
+            self.fragment_bytes.write_all(&chunk).unwrap();
 
             Added::Fragment {
                 frag_index,
@@ -93,12 +98,32 @@ impl DataWriter {
             }
         } else {
             // Add to data bytes
-            let blocks_start = self.data_bytes.len() as u32 + self.data_start;
             let mut block_sizes = vec![];
-            for chunk in chunks {
-                let cb = compress(chunk, self.compressor, &self.compression_options).unwrap();
+            let blocks_start = self.data_bytes.len() as u32 + self.data_start;
+            let mut add_data = |bytes: &[u8]| {
+                let cb = compress(bytes, self.compressor, &self.compression_options).unwrap();
                 block_sizes.push(cb.len() as u32);
                 self.data_bytes.write_all(&cb).unwrap();
+            };
+
+            //the chunk buffer
+            let mut chunk_buf = vec![0u8; self.block_size as usize];
+            //the number of full chunks
+            let chunk_number = len as usize / self.block_size as usize;
+            //the len of the last non full chunk
+            let chunk_last_len = len as usize % self.block_size as usize;
+
+            //add the full chunks
+            for _ in 0..chunk_number {
+                reader.read_exact(&mut chunk_buf).unwrap();
+                add_data(&chunk_buf);
+            }
+            //add the last (if any) chunk, that may not be full
+            if chunk_last_len != 0 {
+                reader
+                    .read_exact(&mut chunk_buf[0..chunk_last_len])
+                    .unwrap();
+                add_data(&chunk_buf[0..chunk_last_len]);
             }
 
             Added::Data {

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -1,5 +1,6 @@
 //! Read from on-disk image
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::io::{Cursor, Read, SeekFrom};
@@ -449,7 +450,7 @@ impl Squashfs {
             mod_time: self.superblock.mod_time,
             id_table: self.id.clone(),
             root_inode,
-            nodes: nodes.to_vec(),
+            nodes,
         };
         Ok(filesystem)
     }
@@ -514,7 +515,7 @@ impl Squashfs {
                             let path = new_path.clone();
                             let inner = InnerNode::File(SquashfsFile {
                                 header: file_header.into(),
-                                bytes,
+                                reader: RefCell::new(Box::new(Cursor::new(bytes))),
                             });
                             let node = Node::new(path, inner);
                             nodes.push(node);

--- a/tests/mutate.rs
+++ b/tests/mutate.rs
@@ -1,5 +1,7 @@
 mod common;
 use std::fs::{self, File};
+use std::cell::RefCell;
+use std::io::Cursor;
 
 use backhand::filesystem::FilesystemHeader;
 use backhand::Filesystem;
@@ -63,7 +65,7 @@ fn test_add_00() {
 
     // Modify file
     let file = og_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
-    file.bytes = b"MODIFIEDfirst file!\n".to_vec();
+    file.reader = RefCell::new(Box::new(Cursor::new(b"MODIFIEDfirst file!\n")));
 
     let bytes = og_filesystem.to_bytes().unwrap();
     fs::write(new_path, bytes).unwrap();


### PR DESCRIPTION
To accomplish that was necessary:

* Remove multiple unnecessary Clone/Copy.
* Pass `TreeNode` and `SquashFs*` types by reference to avoid implicit copy.
* Creation of the trait `SquashfsFileReader`, that will represent the dyn reader.
* Replace the bytes in `SquashfsFile` with a dyn type.

Possible Future Work:
 * Remove the `RefCell` from the reader if possible.
 * Add an API that allow the user to push file from types that implement `Read` and `Seek`