### PR TITLE
Use block_size in default compression XZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Use `block_size` as XZ default `dict_size` when compressing data
+- Correctly choose between storing uncompressed and compressed data on which takes the least space
 
 ## [v0.6.0] - 2023-01-10
 - Fix bug in our filesystem tree causing directory header information (gui, uid, permissions)

--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -112,6 +112,7 @@ pub(crate) fn compress(
     bytes: &[u8],
     compressor: Compressor,
     options: &Option<CompressionOptions>,
+    block_size: u32,
 ) -> Result<Vec<u8>, SquashfsError> {
     match (compressor, options) {
         (Compressor::Xz, Some(CompressionOptions::Xz(xz))) => {
@@ -140,8 +141,7 @@ pub(crate) fn compress(
             let level = 7;
             let check = Check::Crc32;
             let mut opts = LzmaOptions::new_preset(level).unwrap();
-            let dict_size = 0x2000;
-            opts.dict_size(dict_size);
+            opts.dict_size(block_size);
 
             let mut filters = Filters::new();
             filters.lzma2(&opts);
@@ -156,6 +156,7 @@ pub(crate) fn compress(
             let mut encoder = XzEncoder::new_stream(Cursor::new(bytes), stream);
             let mut buf = vec![];
             encoder.read_to_end(&mut buf)?;
+
             Ok(buf)
         },
         (Compressor::Gzip, Some(CompressionOptions::Gzip(gzip))) => {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -116,7 +116,7 @@ mod tests {
     fn test_mwriter() {
         let bytes = [0xffu8; METADATA_MAXSIZE - 3];
 
-        let mut mwriter = MetadataWriter::new(Compressor::Xz, None);
+        let mut mwriter = MetadataWriter::new(Compressor::Xz, None, 0x2000);
 
         mwriter.write_all(&bytes).unwrap();
         assert_eq!(0, mwriter.metadata_start);

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -424,8 +424,8 @@ impl Filesystem {
         let data_start = 96;
 
         let mut data_writer = DataWriter::new(self.compressor, None, data_start, self.block_size);
-        let mut inode_writer = MetadataWriter::new(self.compressor, None);
-        let mut dir_writer = MetadataWriter::new(self.compressor, None);
+        let mut inode_writer = MetadataWriter::new(self.compressor, None, self.block_size);
+        let mut dir_writer = MetadataWriter::new(self.compressor, None, self.block_size);
 
         // Empty Squashfs
         c.write_all(&vec![0x00; data_start as usize])?;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -16,6 +16,7 @@ const METDATA_UNCOMPRESSED: u16 = 1 << 15;
 pub(crate) struct MetadataWriter {
     compressor: Compressor,
     compression_options: Option<CompressionOptions>,
+    block_size: u32,
     /// Offset from the beginning of the metadata block last written
     pub(crate) metadata_start: u32,
     // All current bytes that are uncompressed
@@ -26,10 +27,15 @@ pub(crate) struct MetadataWriter {
 
 impl MetadataWriter {
     #[instrument(skip_all)]
-    pub fn new(compressor: Compressor, compression_options: Option<CompressionOptions>) -> Self {
+    pub fn new(
+        compressor: Compressor,
+        compression_options: Option<CompressionOptions>,
+        block_size: u32,
+    ) -> Self {
         Self {
             compressor,
             compression_options,
+            block_size,
             metadata_start: 0,
             uncompressed_bytes: vec![],
             compressed_bytes: vec![],
@@ -51,6 +57,7 @@ impl MetadataWriter {
             &self.uncompressed_bytes,
             self.compressor,
             &self.compression_options,
+            self.block_size,
         )
         .unwrap();
 
@@ -78,6 +85,7 @@ impl Write for MetadataWriter {
                 &self.uncompressed_bytes[..METADATA_MAXSIZE],
                 self.compressor,
                 &self.compression_options,
+                self.block_size,
             )
             .unwrap();
 

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -10,6 +10,7 @@ use deku::prelude::*;
 use tracing::{error, info, instrument, trace};
 
 use crate::compressor::{self, CompressionOptions, Compressor};
+use crate::data::DATA_STORED_UNCOMPRESSED;
 use crate::dir::{Dir, DirEntry};
 use crate::error::SquashfsError;
 use crate::filesystem::{
@@ -267,7 +268,7 @@ impl Squashfs {
         } else {
             None
         };
-        trace!("compression_options: {compression_options:08x?}");
+        info!("compression_options: {compression_options:02x?}");
 
         // Create SquashfsReader
         let mut squashfs_reader = SquashfsReader::new(reader, offset);
@@ -615,8 +616,8 @@ impl Squashfs {
 
     /// Read from either Data blocks or Fragments blocks
     fn read_data<R: Read>(&self, reader: &mut R, size: usize) -> Result<Vec<u8>, SquashfsError> {
-        let uncompressed = size & (1 << 24) != 0;
-        let size = size & !(1 << 24);
+        let uncompressed = size & (DATA_STORED_UNCOMPRESSED as usize) != 0;
+        let size = size & !(DATA_STORED_UNCOMPRESSED as usize);
         let mut buf = vec![0u8; size];
         reader.read_exact(&mut buf)?;
 


### PR DESCRIPTION
* Use block_size for default compression dict size if compression options aren't present
* Store data uncompressed if compression doens't decrease size of data block