### PR TITLE
SquashfsFileWriter use dyn std::io::Read instead of Vec<u8>

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ backhand = "0.7.0"
 ### Reading/Writing/Modifying Firmware
 ```rust,no_run
 use std::fs::File;
+use std::io::Cursor;
 use backhand::{FilesystemReader, FilesystemWriter, FilesystemHeader};
 
 // read
@@ -39,6 +40,10 @@ write_filesystem.push_file(bytes, "a/d/e/new_file", d);
 // add file with data from file
 let new_file = File::open("dune").unwrap();
 write_filesystem.push_file(new_file, "/root/dune", d);
+
+// modify file
+let file = write_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
+file.reader = RefCell::new(Box::new(Cursor::new(b"The sleeper must awaken.\n")));
 
 // convert into bytes
 let bytes = write_filesystem.to_bytes().unwrap();

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ backhand = "0.7.0"
 ```
 ### Reading/Writing/Modifying Firmware
 ```rust,no_run
+use std::cell::RefCell;
 use std::fs::File;
 use std::io::Cursor;
 use backhand::{FilesystemReader, FilesystemWriter, FilesystemHeader};

--- a/README.md
+++ b/README.md
@@ -33,16 +33,12 @@ let mut write_filesystem = FilesystemWriter::from_fs_reader(&read_filesystem).un
 
 // add file with data from slice
 let d = FilesystemHeader::default();
-let bytes = &mut b"Fear is the mind-killer.".as_slice();
+let bytes = std::io::Cursor::new(b"Fear is the mind-killer.");
 write_filesystem.push_file(bytes, "a/d/e/new_file", d);
 
 // add file with data from file
-let mut new_file = File::open("dune").unwrap();
-write_filesystem.push_file(&mut new_file, "/root/dune", d);
-
-// modify file
-let file = write_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
-file.bytes = b"The sleeper must awaken.\n".to_vec();
+let new_file = File::open("dune").unwrap();
+write_filesystem.push_file(new_file, "/root/dune", d);
 
 // convert into bytes
 let bytes = write_filesystem.to_bytes().unwrap();

--- a/src/bin/add.rs
+++ b/src/bin/add.rs
@@ -31,11 +31,7 @@ fn main() {
     // create new file
     let new_file = File::open(&args.file).unwrap();
     filesystem
-        .push_file(
-            Box::new(new_file),
-            args.file_path,
-            FilesystemHeader::default(),
-        )
+        .push_file(new_file, args.file_path, FilesystemHeader::default())
         .unwrap();
 
     // write new file

--- a/src/bin/add.rs
+++ b/src/bin/add.rs
@@ -29,9 +29,13 @@ fn main() {
     let mut filesystem = FilesystemWriter::from_fs_reader(&filesystem).unwrap();
 
     // create new file
-    let mut new_file = File::open(&args.file).unwrap();
+    let new_file = File::open(&args.file).unwrap();
     filesystem
-        .push_file(&mut new_file, args.file_path, FilesystemHeader::default())
+        .push_file(
+            Box::new(new_file),
+            args.file_path,
+            FilesystemHeader::default(),
+        )
         .unwrap();
 
     // write new file

--- a/src/bin/unsquashfs.rs
+++ b/src/bin/unsquashfs.rs
@@ -75,7 +75,7 @@ fn extract_all(args: &Args) {
                 },
                 InnerNode::Dir(SquashfsDir { header, .. }) => {
                     let path: PathBuf = path.iter().skip(1).collect();
-                    let path = Path::new(&args.dest).join(&path);
+                    let path = Path::new(&args.dest).join(path);
                     tracing::debug!("path {}", path.display());
                     let _ = std::fs::create_dir_all(&path);
                     let perms = Permissions::from_mode(u32::from(header.permissions));

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,6 @@
 //! File Data
 
-use std::io::Write;
+use std::io::{Read, Write};
 
 use tracing::instrument;
 
@@ -21,6 +21,33 @@ pub(crate) enum Added {
         frag_index: u32,
         block_offset: u32,
     },
+}
+
+struct DataWriterChunkReader<R: std::io::Read> {
+    chunk: Vec<u8>,
+    file_len: usize,
+    reader: R,
+}
+impl<R: std::io::Read> DataWriterChunkReader<R> {
+    pub fn read_chunk(&mut self) -> std::io::Result<&[u8]> {
+        use std::io::ErrorKind;
+        let mut buf: &mut [u8] = &mut self.chunk;
+        let mut read_len = 0;
+        while !buf.is_empty() {
+            match self.reader.read(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    read_len += n;
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                },
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {},
+                Err(e) => return Err(e),
+            }
+        }
+        self.file_len += read_len;
+        Ok(&self.chunk[..read_len])
+    }
 }
 
 #[derive(Debug)]
@@ -56,13 +83,17 @@ impl DataWriter {
 
     /// Add to data writer, either a Data or Fragment
     // TODO: support tail-end fragments (off by default in squashfs-tools/mksquashfs)
-    pub(crate) fn add_bytes(&mut self, bytes: &[u8]) -> Added {
-        let mut chunks = bytes.chunks(self.block_size as usize);
+    pub(crate) fn add_bytes(&mut self, reader: impl Read) -> (usize, Added) {
+        let mut chunk_reader = DataWriterChunkReader {
+            chunk: vec![0u8; self.block_size as usize],
+            file_len: 0,
+            reader,
+        };
+        //TODO error
+        let mut chunk = chunk_reader.read_chunk().unwrap();
 
         // only one chunks, and not exactly the size of the block
-        if chunks.len() == 1 && bytes.len() != self.block_size as usize {
-            let chunk = chunks.next().unwrap();
-
+        if chunk.len() != self.block_size as usize {
             // if this doesn't fit in the current fragment bytes, compress and add to data_bytes
             if (chunk.len() + self.fragment_bytes.len()) > self.block_size as usize {
                 // TODO: don't always compress?
@@ -89,19 +120,26 @@ impl DataWriter {
             // add to fragment bytes
             let frag_index = self.fragment_table.len() as u32;
             let block_offset = self.fragment_bytes.len() as u32;
-            self.fragment_bytes.write_all(chunk).unwrap();
+            self.fragment_bytes.write_all(&chunk).unwrap();
 
-            Added::Fragment {
-                frag_index,
-                block_offset,
-            }
+            (
+                chunk_reader.file_len,
+                Added::Fragment {
+                    frag_index,
+                    block_offset,
+                },
+            )
         } else {
             // Add to data bytes
             let blocks_start = self.data_bytes.len() as u32 + self.data_start;
             let mut block_sizes = vec![];
-            for chunk in chunks {
+            loop {
+                //empty chunk, no more data
+                if chunk.len() == 0 {
+                    break;
+                }
                 let cb = compress(
-                    chunk,
+                    &chunk,
                     self.compressor,
                     &self.compression_options,
                     self.block_size,
@@ -112,18 +150,22 @@ impl DataWriter {
                 if cb.len() > chunk.len() {
                     // store uncompressed
                     block_sizes.push(DATA_STORED_UNCOMPRESSED | chunk.len() as u32);
-                    self.data_bytes.write_all(chunk).unwrap();
+                    self.data_bytes.write_all(&chunk).unwrap();
                 } else {
                     // store compressed
                     block_sizes.push(cb.len() as u32);
                     self.data_bytes.write_all(&cb).unwrap();
                 }
+                chunk = chunk_reader.read_chunk().unwrap();
             }
 
-            Added::Data {
-                blocks_start,
-                block_sizes,
-            }
+            (
+                chunk_reader.file_len,
+                Added::Data {
+                    blocks_start,
+                    block_sizes,
+                },
+            )
         }
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -120,7 +120,7 @@ impl DataWriter {
             // add to fragment bytes
             let frag_index = self.fragment_table.len() as u32;
             let block_offset = self.fragment_bytes.len() as u32;
-            self.fragment_bytes.write_all(&chunk).unwrap();
+            self.fragment_bytes.write_all(chunk).unwrap();
 
             (
                 chunk_reader.file_len,
@@ -134,12 +134,11 @@ impl DataWriter {
             let blocks_start = self.data_bytes.len() as u32 + self.data_start;
             let mut block_sizes = vec![];
             loop {
-                //empty chunk, no more data
-                if chunk.len() == 0 {
+                if chunk.is_empty() {
                     break;
                 }
                 let cb = compress(
-                    &chunk,
+                    chunk,
                     self.compressor,
                     &self.compression_options,
                     self.block_size,
@@ -150,7 +149,7 @@ impl DataWriter {
                 if cb.len() > chunk.len() {
                     // store uncompressed
                     block_sizes.push(DATA_STORED_UNCOMPRESSED | chunk.len() as u32);
-                    self.data_bytes.write_all(&chunk).unwrap();
+                    self.data_bytes.write_all(chunk).unwrap();
                 } else {
                     // store compressed
                     block_sizes.push(cb.len() as u32);

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -455,7 +455,7 @@ impl<'a> FilesystemWriter<'a> {
 
         // write child inodes
         for (name, node) in &child_dir_nodes {
-            let node_path = PathBuf::from(name.clone());
+            let node_path = PathBuf::from(name);
             let entry = match node {
                 InnerNode::Dir(path) => Self::path(
                     name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //!### Reading/Writing/Modifying Firmware
 //!```rust,no_run
 //! # use std::fs::File;
+//! # use std::io::Cursor;
 //! # use backhand::{FilesystemReader, FilesystemWriter, FilesystemHeader};
 //!
 //! // read
@@ -28,12 +29,12 @@
 //!
 //! // add file with data from slice
 //! let d = FilesystemHeader::default();
-//! let bytes = &mut b"Fear is the mind-killer.".as_slice();
+//! let bytes = Cursor::new(b"Fear is the mind-killer.");
 //! write_filesystem.push_file(bytes, "a/d/e/new_file", d);
 //!
 //! // add file with data from file
-//! let mut new_file = File::open("dune").unwrap();
-//! write_filesystem.push_file(&mut new_file, "/root/dune", d);
+//! let new_file = File::open("dune").unwrap();
+//! write_filesystem.push_file(new_file, "/root/dune", d);
 //!
 //! // convert into bytes
 //! let bytes = write_filesystem.to_bytes().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //!### Reading/Writing/Modifying Firmware
 //!```rust,no_run
+//! # use std::cell::RefCell;
 //! # use std::fs::File;
 //! # use std::io::Cursor;
 //! # use backhand::{FilesystemReader, FilesystemWriter, FilesystemHeader};
@@ -35,6 +36,10 @@
 //! // add file with data from file
 //! let new_file = File::open("dune").unwrap();
 //! write_filesystem.push_file(new_file, "/root/dune", d);
+//!
+//! // modify file
+//! let file = write_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
+//! file.reader = RefCell::new(Box::new(Cursor::new(b"The sleeper must awaken.\n")));
 //!
 //! // convert into bytes
 //! let bytes = write_filesystem.to_bytes().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,6 @@
 //! let mut new_file = File::open("dune").unwrap();
 //! write_filesystem.push_file(&mut new_file, "/root/dune", d);
 //!
-//! // modify file
-//! let file = write_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
-//! file.bytes = b"The sleeper must awaken.\n".to_vec();
-//!
 //! // convert into bytes
 //! let bytes = write_filesystem.to_bytes().unwrap();
 //! ```

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -457,7 +457,7 @@ impl<R: SquashFsReader> Squashfs<R> {
             id_table: self.id.clone(),
             fragments: self.fragments,
             root_inode,
-            nodes: nodes.to_vec(),
+            nodes,
             reader: RefCell::new(self.file),
             cache: RefCell::new(Cache::default()),
         };

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -50,7 +50,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
 
             // no rest, we have the file
             let node = if rest.is_empty() {
-                Some(og_node.clone())
+                Some(og_node)
             } else {
                 None
             };

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -24,13 +24,13 @@ fn normalized_components(path: &Path) -> Vec<&OsStr> {
 }
 
 #[derive(Debug)]
-pub(crate) struct TreeNode {
+pub(crate) struct TreeNode<'a, 'b> {
     pub fullpath: PathBuf,
-    pub node: Option<InnerNode<SquashfsFileWriter>>,
-    pub children: BTreeMap<PathBuf, TreeNode>,
+    pub node: Option<&'b InnerNode<SquashfsFileWriter<'a>>>,
+    pub children: BTreeMap<PathBuf, TreeNode<'a, 'b>>,
 }
 
-impl TreeNode {
+impl<'a, 'b> TreeNode<'a, 'b> {
     pub(crate) fn name(&self) -> OsString {
         if let Some(path) = self.fullpath.as_path().file_name() {
             path.into()
@@ -43,7 +43,7 @@ impl TreeNode {
         &mut self,
         fullpath: &mut PathBuf,
         components: &[&OsStr],
-        og_node: &InnerNode<SquashfsFileWriter>,
+        og_node: &'b InnerNode<SquashfsFileWriter<'a>>,
     ) {
         if let Some((first, rest)) = components.split_first() {
             fullpath.push(first);
@@ -67,8 +67,8 @@ impl TreeNode {
     }
 }
 
-impl From<&FilesystemWriter> for TreeNode {
-    fn from(fs: &FilesystemWriter) -> Self {
+impl<'a, 'b> From<&'b FilesystemWriter<'a>> for TreeNode<'a, 'b> {
+    fn from(fs: &'b FilesystemWriter<'a>) -> Self {
         let mut tree = TreeNode {
             fullpath: "/".into(),
             node: None,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -49,7 +49,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
             fullpath.push(first);
 
             // no rest, we have the file
-            let node = rest.is_empty().then(|| og_node);
+            let node = rest.is_empty().then_some(og_node);
             let entry = self
                 .children
                 .entry(fullpath.to_path_buf())

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
@@ -31,11 +31,11 @@ pub(crate) struct TreeNode<'a, 'b> {
 }
 
 impl<'a, 'b> TreeNode<'a, 'b> {
-    pub(crate) fn name(&self) -> OsString {
+    pub(crate) fn name(&self) -> &OsStr {
         if let Some(path) = self.fullpath.as_path().file_name() {
-            path.into()
+            path
         } else {
-            "/".into()
+            "/".as_ref()
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -49,11 +49,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
             fullpath.push(first);
 
             // no rest, we have the file
-            let node = if rest.is_empty() {
-                Some(og_node)
-            } else {
-                None
-            };
+            let node = rest.is_empty().then(|| og_node);
             let entry = self
                 .children
                 .entry(fullpath.to_path_buf())

--- a/tests/mutate.rs
+++ b/tests/mutate.rs
@@ -53,14 +53,14 @@ fn test_add_00() {
     let mut new_filesystem = FilesystemWriter::from_fs_reader(&og_filesystem).unwrap();
 
     // Add file
-    let bytes = &mut b"this is a new file, wowo!".as_slice();
+    let bytes = Cursor::new(b"this is a new file, wowo!");
     new_filesystem
         .push_file(bytes, "a/d/e/new_file", FilesystemHeader::default())
         .unwrap();
     // Add file
     new_filesystem
         .push_file(
-            &mut Cursor::new("i am (g)root"),
+            Cursor::new("i am (g)root"),
             "root_file",
             FilesystemHeader::default(),
         )
@@ -68,15 +68,15 @@ fn test_add_00() {
     // Add file
     new_filesystem
         .push_file(
-            &mut Cursor::new("dude"),
+            Cursor::new("dude"),
             "a/b/c/d/dude",
             FilesystemHeader::default(),
         )
         .unwrap();
 
     // Modify file
-    let file = new_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
-    file.bytes = b"MODIFIEDfirst file!\n".to_vec();
+    //let file = new_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
+    //file.bytes = b"MODIFIEDfirst file!\n".to_vec();
 
     let bytes = new_filesystem.to_bytes().unwrap();
     fs::write(new_path, bytes).unwrap();

--- a/tests/mutate.rs
+++ b/tests/mutate.rs
@@ -1,4 +1,5 @@
 mod common;
+use std::cell::RefCell;
 use std::fs::{self, File};
 use std::io::Cursor;
 
@@ -42,6 +43,11 @@ fn test_add_00() {
             hash: "dc02848152d42b331fa0540000f68bf0942c5b00a3a44a3a6f208af34b4b6ec3".to_string(),
             url: "wcampbell.dev/squashfs/testing/test_add_00/new.squashfs".to_string(),
         },
+        TestAssetDef {
+            filename: "control.squashfs".to_string(),
+            hash: "a227c214be3efbd9b6958918e23d13f4c98de7a1fde64c2a5ede1c4c69938930".to_string(),
+            url: "wcampbell.dev/squashfs/testing/test_add_00/control.squashfs".to_string(),
+        },
     ];
     const TEST_PATH: &str = "test-assets/test_add_00";
     let og_path = format!("{TEST_PATH}/out.squashfs");
@@ -52,35 +58,34 @@ fn test_add_00() {
     let og_filesystem = FilesystemReader::from_reader(file).unwrap();
     let mut new_filesystem = FilesystemWriter::from_fs_reader(&og_filesystem).unwrap();
 
+    let h = FilesystemHeader {
+        permissions: 0o755,
+        uid: 0,
+        gid: 0,
+        mtime: 0,
+    };
+
     // Add file
     let bytes = Cursor::new(b"this is a new file, wowo!");
     new_filesystem
-        .push_file(bytes, "a/d/e/new_file", FilesystemHeader::default())
+        .push_file(bytes, "a/d/e/new_file", h)
         .unwrap();
     // Add file
     new_filesystem
-        .push_file(
-            Cursor::new("i am (g)root"),
-            "root_file",
-            FilesystemHeader::default(),
-        )
+        .push_file(Cursor::new("i am (g)root"), "root_file", h)
         .unwrap();
     // Add file
     new_filesystem
-        .push_file(
-            Cursor::new("dude"),
-            "a/b/c/d/dude",
-            FilesystemHeader::default(),
-        )
+        .push_file(Cursor::new("dude"), "a/b/c/d/dude", h)
         .unwrap();
 
     // Modify file
-    //let file = new_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
-    //file.bytes = b"MODIFIEDfirst file!\n".to_vec();
+    let file = new_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
+    file.reader = RefCell::new(Box::new(Cursor::new(b"MODIFIEDfirst file!\n")));
 
     let bytes = new_filesystem.to_bytes().unwrap();
-    fs::write(new_path, bytes).unwrap();
+    fs::write(&new_path, bytes).unwrap();
 
-    let new_path = format!("{TEST_PATH}/new.squashfs");
-    test_unsquashfs(&new_path, &new_path, None);
+    let control_new_path = format!("{TEST_PATH}/control.squashfs");
+    test_unsquashfs(&new_path, &control_new_path, None);
 }


### PR DESCRIPTION
This was the disadvantage of now allowing the `mut_file` function.

This function could be viable again if we use the `Any` trait and downcast it, but it is a kind of a hack.