### PR TITLE
Remove the to_bytes api and replace it by write

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ let new_file = File::open("dune").unwrap();
 write_filesystem.push_file(new_file, "/root/dune", d);
 
 // modify file
-let file = write_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
-file.reader = RefCell::new(Box::new(Cursor::new(b"The sleeper must awaken.\n")));
+let bytes = Cursor::new(b"The sleeper must awaken.\n");
+let file = write_filesystem.replace_file("/a/b/c/d/e/first_file", bytes).unwrap();
 
-// convert into bytes
-let bytes = write_filesystem.to_bytes().unwrap();
+// write into a new file
+let mut output = File::create("modified.squashfs").unwrap();
+write_filesystem.write(&mut output).unwrap();
 ```
 
 ## Testing

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::io::Cursor;
 
 use backhand::{FilesystemReader, FilesystemWriter};
 use criterion::*;
@@ -9,7 +10,8 @@ fn read_write(file: File, offset: u64) {
     let new_filesystem = FilesystemWriter::from_fs_reader(&og_filesystem).unwrap();
 
     // convert to bytes
-    black_box(new_filesystem.to_bytes().unwrap());
+    let mut output = Cursor::new(vec![]);
+    black_box(new_filesystem.write(&mut output).unwrap());
 }
 
 fn read(file: File, offset: u64) {

--- a/src/bin/add.rs
+++ b/src/bin/add.rs
@@ -35,7 +35,7 @@ fn main() {
         .unwrap();
 
     // write new file
-    let bytes = filesystem.to_bytes().unwrap();
-    std::fs::write("added.squashfs", bytes).unwrap();
+    let mut output = File::create("added.squashfs").unwrap();
+    filesystem.write(&mut output).unwrap();
     println!("added file and wrote to added.squashfs");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,15 @@
 //! let new_file = File::open("dune").unwrap();
 //! write_filesystem.push_file(new_file, "/root/dune", d);
 //!
-//! // modify file
-//! let file = write_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
-//! file.reader = RefCell::new(Box::new(Cursor::new(b"The sleeper must awaken.\n")));
+//! // replace a existing file
+//! let bytes = Cursor::new(b"The sleeper must awaken.\n");
+//! write_filesystem
+//!     .replace_file("/a/b/c/d/e/first_file", bytes)
+//!     .unwrap();
 //!
-//! // convert into bytes
-//! let bytes = write_filesystem.to_bytes().unwrap();
+//! // write into a new file
+//! let mut output = File::create("modified.squashfs").unwrap();
+//! write_filesystem.write(&mut output).unwrap();
 //! ```
 
 #[doc = include_str!("../README.md")]

--- a/tests/mutate.rs
+++ b/tests/mutate.rs
@@ -1,6 +1,6 @@
 mod common;
 use std::cell::RefCell;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::Cursor;
 
 use backhand::filesystem::{FilesystemHeader, FilesystemReader};
@@ -88,9 +88,9 @@ fn test_add_00() {
     let file = new_filesystem.mut_file("/a/b/c/d/e/first_file").unwrap();
     file.reader = RefCell::new(Box::new(Cursor::new(b"MODIFIEDfirst file!\n")));
 
-    // to bytes
-    let bytes = new_filesystem.to_bytes().unwrap();
-    fs::write(&new_path, bytes).unwrap();
+    // create the modified squashfs
+    let mut output = File::create(&new_path).unwrap();
+    new_filesystem.write(&mut output).unwrap();
 
     // compare
     let control_new_path = format!("{TEST_PATH}/control.squashfs");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
 mod common;
-use std::fs::{self, File};
+use std::fs::File;
 
 use backhand::filesystem::FilesystemReader;
 use backhand::FilesystemWriter;
@@ -38,12 +38,13 @@ fn full_test(
 
     // convert to bytes
     info!("calling to_bytes");
-    let bytes = new_filesystem.to_bytes().unwrap();
-    fs::write(&new_path, &bytes).unwrap();
+    let mut output = File::create(&new_path).unwrap();
+    new_filesystem.write(&mut output).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
     info!("calling from_reader");
-    let _new_filesystem = FilesystemReader::from_reader(std::io::Cursor::new(bytes)).unwrap();
+    let created_file = File::open(&new_path).unwrap();
+    let _new_filesystem = FilesystemReader::from_reader(created_file).unwrap();
 
     info!("starting unsquashfs test");
     match verify {


### PR DESCRIPTION
The `FilesystemWriter::to_bytes` is impractical with very big files, because it require the output file to be completely be stored in ram.

I suggest to remove this api and instead suggest the use of `FilesystemWriter::write` and `FilesystemWriter::write_with_offset`.