### PR TITLE
Restructure FilesystemWrite::write to avoid unecessary ram allocations

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -32,6 +32,7 @@ impl Entry {
         std::str::from_utf8(&self.name).unwrap().to_string()
     }
     /// Write data and metadata for path node
+    #[allow(clippy::too_many_arguments)]
     pub fn path(
         name: &OsStr,
         path: &SquashfsDir,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -72,6 +72,9 @@ impl Entry {
     /// Create alphabetically sorted entries
     #[instrument(skip_all)]
     pub(crate) fn into_dir(entries: &mut [Entry]) -> Vec<Dir> {
+        if entries.is_empty() {
+            return vec![];
+        }
         entries.sort_unstable_by(|a, b| a.name.cmp(&b.name));
 
         let mut dirs = vec![];

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -28,7 +28,7 @@ pub(crate) struct Entry<'a> {
 
 impl<'a> Entry<'a> {
     pub fn name(&self) -> String {
-        std::str::from_utf8(&self.name).unwrap().to_string()
+        std::str::from_utf8(self.name).unwrap().to_string()
     }
     /// Write data and metadata for path node
     #[allow(clippy::too_many_arguments)]
@@ -227,7 +227,7 @@ impl<'a> Entry<'a> {
     /// Create alphabetically sorted entries
     #[instrument(skip_all)]
     pub(crate) fn into_dir(mut entries: Vec<Self>) -> Vec<Dir> {
-        entries.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+        entries.sort_unstable_by(|a, b| a.name.cmp(b.name));
 
         let mut dirs = vec![];
         let mut creating_dir = vec![];

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -596,6 +596,7 @@ impl<'a> FilesystemWriter<'a> {
             &mut inode_writer,
             &mut dir_writer,
             &mut data_writer,
+            0,
         )?;
 
         // Compress everything

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -23,7 +23,7 @@ pub struct Inode {
 
 impl Inode {
     /// Write to `m_writer`, creating Entry
-    pub(crate) fn to_bytes(&self, name_bytes: &[u8], m_writer: &mut MetadataWriter) -> Entry {
+    pub(crate) fn to_bytes<'a>(&self, name: &'a [u8], m_writer: &mut MetadataWriter) -> Entry<'a> {
         let mut v = BitVec::<u8, Msb0>::new();
         self.write(&mut v, (0, 0)).unwrap();
         let bytes = v.as_raw_slice().to_vec();
@@ -36,8 +36,8 @@ impl Inode {
             offset,
             inode: self.header.inode_number,
             t: self.id,
-            name_size: name_bytes.len() as u16 - 1,
-            name: name_bytes.to_vec(),
+            name_size: name.len() as u16 - 1,
+            name,
         }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Write, Seek};
 
 use tracing::{instrument, trace};
 
@@ -41,11 +41,10 @@ impl MetadataWriter {
     }
 
     #[instrument(skip_all)]
-    pub fn finalize(&mut self) -> Vec<u8> {
-        let mut out = vec![];
+    pub fn finalize<W: Write + Seek>(&mut self, out: &mut W) -> Result<(), SquashfsError> {
         for cb in &self.compressed_bytes {
             trace!("len: {:02x?}", cb.len());
-            trace!("total: {:02x?}", out.len());
+            //trace!("total: {:02x?}", out.len());
             out.write_all(&(cb.len() as u16).to_le_bytes()).unwrap();
             out.write_all(cb).unwrap();
         }
@@ -59,11 +58,10 @@ impl MetadataWriter {
         .unwrap();
 
         trace!("len: {:02x?}", b.len());
-        trace!("total: {:02x?}", out.len());
+        //trace!("total: {:02x?}", out.len());
         out.write_all(&(b.len() as u16).to_le_bytes()).unwrap();
         out.write_all(&b).unwrap();
-
-        out
+        Ok(())
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Write, Seek};
+use std::io::{self, Read, Seek, Write};
 
 use tracing::{instrument, trace};
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -48,7 +48,7 @@ pub trait SquashFsReader: Read + Seek {
     /// Read in entire data and fragments
     #[instrument(skip_all)]
     fn data_and_fragments(&mut self, superblock: &SuperBlock) -> Result<Vec<u8>, SquashfsError> {
-        self.seek(SeekFrom::Start(0))?;
+        self.rewind()?;
         let mut buf = vec![0u8; superblock.inode_table as usize];
         self.read_exact(&mut buf)?;
         Ok(buf)

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::hash::BuildHasherDefault;
-use std::io::SeekFrom;
 use std::os::unix::prelude::OsStringExt;
 use std::path::{Path, PathBuf};
 
@@ -242,7 +241,7 @@ impl<R: SquashFsReader> Squashfs<SquashfsReaderWithOffset<R>> {
 impl<R: SquashFsReader> Squashfs<R> {
     #[instrument(skip_all)]
     fn inner_from_reader(mut reader: R) -> Result<Squashfs<R>, SquashfsError> {
-        reader.seek(SeekFrom::Start(0))?;
+        reader.rewind()?;
 
         // Size of metadata + optional compression options metadata block
         let mut superblock = [0u8; 96];

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::io::{Seek, Write};
-use std::os::unix::prelude::OsStrExt;
 use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
@@ -121,8 +120,8 @@ impl<'a, 'b> TreeNode<'a, 'b> {
         inode_writer: &'_ mut MetadataWriter,
         dir_writer: &'_ mut MetadataWriter,
         data_writer: &'_ mut DataWriter,
+        parent_inode: u32,
     ) -> Result<(Entry, u64), SquashfsError> {
-        let parent_inode = *inode_counter;
         *inode_counter += 1;
         let this_inode = *inode_counter;
 
@@ -163,6 +162,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
                             inode_writer,
                             dir_writer,
                             data_writer,
+                            this_inode,
                         )
                         .map(|res| res.0) // only entry
                     })

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,7 +5,7 @@ use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
 use deku::DekuContainerWrite;
-use tracing::trace;
+use tracing::{instrument, trace};
 
 use crate::data::DataWriter;
 use crate::entry::Entry;
@@ -127,7 +127,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
     /// This works my recursively creating Inodes and Dirs for each node in the tree. This also
     /// keeps track of parent directories by calling this function on all nodes of a dir to get only
     /// the nodes, but going into the child dirs in the case that it contains a child dir.
-    //#[instrument(skip_all)]
+    #[instrument(skip_all)]
     #[allow(clippy::type_complexity)]
     pub fn write<W: Write + Seek>(
         &'b self,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -174,7 +174,6 @@ impl<'a, 'b> TreeNode<'a, 'b> {
 
         // write child inodes
         for node in dir.values().filter(|c| !c.have_children()) {
-            let node_path = PathBuf::from(node.name());
             let entry = match &node.inner {
                 InnerTreeNode::Dir(path, _) => Entry::path(
                     node.name(),
@@ -187,7 +186,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
                     dir_writer.metadata_start,
                 ),
                 InnerTreeNode::File(file) => Entry::file(
-                    &node_path,
+                    node.name(),
                     file,
                     writer,
                     *inode_counter,
@@ -195,13 +194,13 @@ impl<'a, 'b> TreeNode<'a, 'b> {
                     inode_writer,
                 ),
                 InnerTreeNode::Symlink(symlink) => {
-                    Entry::symlink(&node_path, symlink, *inode_counter, inode_writer)
+                    Entry::symlink(node.name(), symlink, *inode_counter, inode_writer)
                 },
                 InnerTreeNode::CharacterDevice(char) => {
-                    Entry::char(&node_path, char, *inode_counter, inode_writer)
+                    Entry::char(node.name(), char, *inode_counter, inode_writer)
                 },
                 InnerTreeNode::BlockDevice(block) => {
-                    Entry::block_device(&node_path, block, *inode_counter, inode_writer)
+                    Entry::block_device(node.name(), block, *inode_counter, inode_writer)
                 },
             };
             write_entries.push(entry);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,10 @@ use std::ffi::OsStr;
 use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
-use crate::filesystem::{FilesystemWriter, InnerNode, SquashfsFileWriter};
+use crate::filesystem::{
+    FilesystemWriter, InnerNode, SquashfsBlockDevice, SquashfsCharacterDevice, SquashfsDir,
+    SquashfsFileWriter, SquashfsSymlink,
+};
 
 fn normalized_components(path: &Path) -> Vec<&OsStr> {
     let mut v = Vec::new();
@@ -26,8 +29,16 @@ fn normalized_components(path: &Path) -> Vec<&OsStr> {
 #[derive(Debug)]
 pub(crate) struct TreeNode<'a, 'b> {
     pub fullpath: PathBuf,
-    pub node: Option<&'b InnerNode<SquashfsFileWriter<'a>>>,
-    pub children: BTreeMap<PathBuf, TreeNode<'a, 'b>>,
+    pub inner: InnerTreeNode<'a, 'b>,
+}
+
+#[derive(Debug)]
+pub(crate) enum InnerTreeNode<'a, 'b> {
+    File(&'b SquashfsFileWriter<'a>),
+    Symlink(&'b SquashfsSymlink),
+    Dir(&'b SquashfsDir, BTreeMap<PathBuf, TreeNode<'a, 'b>>),
+    CharacterDevice(&'b SquashfsCharacterDevice),
+    BlockDevice(&'b SquashfsBlockDevice),
 }
 
 impl<'a, 'b> TreeNode<'a, 'b> {
@@ -39,26 +50,55 @@ impl<'a, 'b> TreeNode<'a, 'b> {
         }
     }
 
+    pub(crate) fn from_inner_node(
+        fullpath: PathBuf,
+        inner_node: &'b InnerNode<SquashfsFileWriter<'a>>,
+    ) -> Self {
+        let inner = match inner_node {
+            InnerNode::File(file) => InnerTreeNode::File(file),
+            InnerNode::Symlink(sym) => InnerTreeNode::Symlink(sym),
+            InnerNode::Dir(dir) => InnerTreeNode::Dir(dir, BTreeMap::new()),
+            InnerNode::CharacterDevice(char) => InnerTreeNode::CharacterDevice(char),
+            InnerNode::BlockDevice(block) => InnerTreeNode::BlockDevice(block),
+        };
+        Self { fullpath, inner }
+    }
+
     fn insert(
         &mut self,
         fullpath: &mut PathBuf,
         components: &[&OsStr],
         og_node: &'b InnerNode<SquashfsFileWriter<'a>>,
     ) {
-        if let Some((first, rest)) = components.split_first() {
-            fullpath.push(first);
+        let (first, rest) = match components {
+            [first, rest @ ..] => (first, rest),
+            _ => todo!("Error node have no name"),
+        };
+        fullpath.push(first);
+        let dir = match &mut self.inner {
+            InnerTreeNode::Dir(_, dir) => dir,
+            _ => todo!("Error node inside non-Dir"),
+        };
 
-            // no rest, we have the file
-            let node = rest.is_empty().then_some(og_node);
-            let entry = self
-                .children
-                .entry(fullpath.to_path_buf())
-                .or_insert(TreeNode {
-                    fullpath: fullpath.clone(),
-                    node,
-                    children: BTreeMap::new(),
-                });
-            entry.insert(fullpath, rest, og_node);
+        let is_file = rest.is_empty();
+        let children = dir.get_mut(fullpath);
+        match (is_file, children) {
+            //this file already exists
+            (true, Some(_file)) => {
+                //TODO directory is allowed to be duplicated???
+                //todo!("Error File already exists in the tree")
+            },
+            //this file don't exist in this dir, add it
+            (true, None) => {
+                dir.insert(
+                    fullpath.to_owned(),
+                    Self::from_inner_node(fullpath.to_owned(), og_node),
+                );
+            },
+            //not a file, dir, and it already exists
+            (false, Some(dir)) => dir.insert(fullpath, rest, og_node),
+            //not a file, dir, but the dir don't exits
+            _ => todo!("Error Dir don't exists"),
         }
     }
 }
@@ -67,8 +107,7 @@ impl<'a, 'b> From<&'b FilesystemWriter<'a>> for TreeNode<'a, 'b> {
     fn from(fs: &'b FilesystemWriter<'a>) -> Self {
         let mut tree = TreeNode {
             fullpath: "/".into(),
-            node: None,
-            children: BTreeMap::new(),
+            inner: InnerTreeNode::Dir(&fs.root_inode, BTreeMap::new()),
         };
         for node in &fs.nodes {
             let path = node.path.as_path();


### PR DESCRIPTION
Currently the implementation of `FilesystemWrite::write` is impractical for big files, such in the https://github.com/wcampbell0x2a/backhand/pull/37 that could require more then 16G or ram. 

This require an rewrite of the function and all it's internal components.