### PR TITLE
Restructure FilesystemWriter::write

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -103,7 +103,6 @@ impl DataWriter {
             // add to fragment bytes
             let frag_index = self.fragment_table.len() as u32;
             let block_offset = self.fragment_bytes.len() as u32;
-            assert!(self.fragment_bytes.len() < 10_000_000);
             self.fragment_bytes.write_all(chunk)?;
 
             Ok((
@@ -163,11 +162,9 @@ impl DataWriter {
         let size = if cb.len() > self.fragment_bytes.len() {
             // store uncompressed
             writer.write_all(&self.fragment_bytes)?;
-            println!("u: {:02x?} {:02x?}", cb.len(), self.fragment_bytes.len());
             DATA_STORED_UNCOMPRESSED | self.fragment_bytes.len() as u32
         } else {
             // store compressed
-            println!("c: {:02x?} {:02x?}", cb.len(), self.fragment_bytes.len());
             writer.write_all(&cb)?;
             cb.len() as u32
         };

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,6 +10,7 @@ use crate::fragment::Fragment;
 // bitflag for data size field in inode for signifying that the data is uncompressed
 pub(crate) const DATA_STORED_UNCOMPRESSED: u32 = 1 << 24;
 
+#[derive(Debug, Clone)]
 pub(crate) enum Added {
     // Only Data was added
     Data {

--- a/src/data.rs
+++ b/src/data.rs
@@ -114,12 +114,13 @@ impl DataWriter {
                 self.fragment_table.push(frag);
                 writer.write_all(&cb).unwrap();
 
-                self.fragment_bytes = Vec::with_capacity(self.block_size as usize);
+                self.fragment_bytes = vec![];
             }
 
             // add to fragment bytes
             let frag_index = self.fragment_table.len() as u32;
             let block_offset = self.fragment_bytes.len() as u32;
+            assert!(self.fragment_bytes.len() < 10_000_000);
             self.fragment_bytes.write_all(chunk).unwrap();
 
             (

--- a/src/data.rs
+++ b/src/data.rs
@@ -104,7 +104,7 @@ impl DataWriter {
             let frag_index = self.fragment_table.len() as u32;
             let block_offset = self.fragment_bytes.len() as u32;
             assert!(self.fragment_bytes.len() < 10_000_000);
-            self.fragment_bytes.write_all(chunk).unwrap();
+            self.fragment_bytes.write_all(chunk)?;
 
             Ok((
                 chunk_reader.file_len,
@@ -123,20 +123,19 @@ impl DataWriter {
                     self.compressor,
                     &self.compression_options,
                     self.block_size,
-                )
-                .unwrap();
+                )?;
 
                 // compression didn't reduce size
                 if cb.len() > chunk.len() {
                     // store uncompressed
                     block_sizes.push(DATA_STORED_UNCOMPRESSED | chunk.len() as u32);
-                    writer.write_all(chunk).unwrap();
+                    writer.write_all(chunk)?;
                 } else {
                     // store compressed
                     block_sizes.push(cb.len() as u32);
-                    writer.write_all(&cb).unwrap();
+                    writer.write_all(&cb)?;
                 }
-                chunk = chunk_reader.read_chunk().unwrap();
+                chunk = chunk_reader.read_chunk()?;
             }
 
             Ok((

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -32,6 +32,7 @@ impl Entry {
         std::str::from_utf8(&self.name).unwrap().to_string()
     }
     /// Write data and metadata for path node
+    #[allow(clippy::too_many_arguments)]
     pub fn path(
         name: &OsStr,
         path: &SquashfsDir,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -72,6 +72,9 @@ impl Entry {
     /// Create alphabetically sorted entries
     #[instrument(skip_all)]
     pub(crate) fn into_dir(entries: &mut [Entry]) -> Vec<Dir> {
+        if entries.is_empty() {
+            return vec![];
+        }
         entries.sort_unstable_by(|a, b| a.name.cmp(&b.name));
 
         let mut dirs = vec![];

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -28,7 +28,7 @@ pub(crate) struct Entry<'a> {
 
 impl<'a> Entry<'a> {
     pub fn name(&self) -> String {
-        std::str::from_utf8(&self.name).unwrap().to_string()
+        std::str::from_utf8(self.name).unwrap().to_string()
     }
     /// Write data and metadata for path node
     #[allow(clippy::too_many_arguments)]
@@ -227,7 +227,7 @@ impl<'a> Entry<'a> {
     /// Create alphabetically sorted entries
     #[instrument(skip_all)]
     pub(crate) fn into_dir(mut entries: Vec<Self>) -> Vec<Dir> {
-        entries.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+        entries.sort_unstable_by(|a, b| a.name.cmp(b.name));
 
         let mut dirs = vec![];
         let mut creating_dir = vec![];

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -458,7 +458,7 @@ impl<'a> FilesystemWriter<'a> {
         data_writer.finalize(w);
 
         info!("Writing Other stuff");
-        let (_, root_inode) = tree.write_other(&mut inode_writer, &mut dir_writer, 0)?;
+        let (_, root_inode) = tree.write_inode_dir(&mut inode_writer, &mut dir_writer, 0)?;
 
         superblock.root_inode = root_inode;
         superblock.inode_count = self.nodes.len() as u32 + 1; // + 1 for the "/"

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -455,7 +455,7 @@ impl<'a> FilesystemWriter<'a> {
         tree.write_data(w, &mut data_writer)?;
         info!("Writing Data Fragments");
         // Compress fragments and write
-        data_writer.finalize(w);
+        data_writer.finalize(w)?;
 
         info!("Writing Other stuff");
         let (_, root_inode) = tree.write_inode_dir(&mut inode_writer, &mut dir_writer, 0)?;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -596,6 +596,7 @@ impl<'a> FilesystemWriter<'a> {
             &mut inode_writer,
             &mut dir_writer,
             &mut data_writer,
+            0,
         )?;
 
         // Compress everything

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -134,7 +134,7 @@ impl<'a, R: SquashFsReader> Read for FilesystemFileReader<'a, R> {
                 return Ok(0);
             },
         }
-        //r1eturn data from the read block/fragment
+        //return data from the read block/fragment
         let read = inner.read_available(buf);
         if read == 0 {
             self.0 = None;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -436,24 +436,16 @@ impl<'a> FilesystemWriter<'a> {
         let mut dir_writer = MetadataWriter::new(self.compressor, None, self.block_size);
 
         info!("Creating Inodes and Dirs");
-        let mut inode = 1;
-
         //trace!("TREE: {:#02x?}", tree);
-        let (_, root_inode) = tree.write(
-            &mut inode,
-            w,
-            &mut inode_writer,
-            &mut dir_writer,
-            &mut data_writer,
-            0,
-        )?;
+        let (_, root_inode) =
+            tree.write(w, &mut inode_writer, &mut dir_writer, &mut data_writer, 0)?;
 
         // Compress everything
         info!("Writing Data");
         data_writer.finalize(w);
 
         superblock.root_inode = root_inode;
-        superblock.inode_count = inode - 1;
+        superblock.inode_count = self.nodes.len() as u32 + 1; // + 1 for the "/"
         superblock.block_size = self.block_size;
         superblock.block_log = self.block_log;
         superblock.mod_time = self.mod_time;

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -23,7 +23,7 @@ pub struct Inode {
 
 impl Inode {
     /// Write to `m_writer`, creating Entry
-    pub(crate) fn to_bytes(&self, name_bytes: &[u8], m_writer: &mut MetadataWriter) -> Entry {
+    pub(crate) fn to_bytes<'a>(&self, name: &'a [u8], m_writer: &mut MetadataWriter) -> Entry<'a> {
         let mut v = BitVec::<u8, Msb0>::new();
         self.write(&mut v, (0, 0)).unwrap();
         let bytes = v.as_raw_slice().to_vec();
@@ -36,8 +36,8 @@ impl Inode {
             offset,
             inode: self.header.inode_number,
             t: self.id,
-            name_size: name_bytes.len() as u16 - 1,
-            name: name_bytes.to_vec(),
+            name_size: name.len() as u16 - 1,
+            name,
         }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Write, Seek};
 
 use tracing::{instrument, trace};
 
@@ -41,11 +41,10 @@ impl MetadataWriter {
     }
 
     #[instrument(skip_all)]
-    pub fn finalize(&mut self) -> Vec<u8> {
-        let mut out = vec![];
+    pub fn finalize<W: Write + Seek>(&mut self, out: &mut W) -> Result<(), SquashfsError> {
         for cb in &self.compressed_bytes {
             trace!("len: {:02x?}", cb.len());
-            trace!("total: {:02x?}", out.len());
+            //trace!("total: {:02x?}", out.len());
             out.write_all(&(cb.len() as u16).to_le_bytes()).unwrap();
             out.write_all(cb).unwrap();
         }
@@ -59,11 +58,10 @@ impl MetadataWriter {
         .unwrap();
 
         trace!("len: {:02x?}", b.len());
-        trace!("total: {:02x?}", out.len());
+        //trace!("total: {:02x?}", out.len());
         out.write_all(&(b.len() as u16).to_le_bytes()).unwrap();
         out.write_all(&b).unwrap();
-
-        out
+        Ok(())
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -45,8 +45,8 @@ impl MetadataWriter {
         for cb in &self.compressed_bytes {
             trace!("len: {:02x?}", cb.len());
             //trace!("total: {:02x?}", out.len());
-            out.write_all(&(cb.len() as u16).to_le_bytes()).unwrap();
-            out.write_all(cb).unwrap();
+            out.write_all(&(cb.len() as u16).to_le_bytes())?;
+            out.write_all(cb)?;
         }
 
         let b = compressor::compress(
@@ -54,13 +54,12 @@ impl MetadataWriter {
             self.compressor,
             &self.compression_options,
             self.block_size,
-        )
-        .unwrap();
+        )?;
 
         trace!("len: {:02x?}", b.len());
         //trace!("total: {:02x?}", out.len());
-        out.write_all(&(b.len() as u16).to_le_bytes()).unwrap();
-        out.write_all(&b).unwrap();
+        out.write_all(&(b.len() as u16).to_le_bytes())?;
+        out.write_all(&b)?;
         Ok(())
     }
 }
@@ -79,8 +78,7 @@ impl Write for MetadataWriter {
                 self.compressor,
                 &self.compression_options,
                 self.block_size,
-            )
-            .unwrap();
+            )?;
 
             // Metadata len + bytes + last metadata_start
             self.metadata_start += 2 + b.len() as u32;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Write, Seek};
+use std::io::{self, Read, Seek, Write};
 
 use tracing::{instrument, trace};
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -48,7 +48,7 @@ pub trait SquashFsReader: Read + Seek {
     /// Read in entire data and fragments
     #[instrument(skip_all)]
     fn data_and_fragments(&mut self, superblock: &SuperBlock) -> Result<Vec<u8>, SquashfsError> {
-        self.seek(SeekFrom::Start(0))?;
+        self.rewind()?;
         let mut buf = vec![0u8; superblock.inode_table as usize];
         self.read_exact(&mut buf)?;
         Ok(buf)

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::hash::BuildHasherDefault;
-use std::io::SeekFrom;
 use std::os::unix::prelude::OsStringExt;
 use std::path::{Path, PathBuf};
 
@@ -242,7 +241,7 @@ impl<R: SquashFsReader> Squashfs<SquashfsReaderWithOffset<R>> {
 impl<R: SquashFsReader> Squashfs<R> {
     #[instrument(skip_all)]
     fn inner_from_reader(mut reader: R) -> Result<Squashfs<R>, SquashfsError> {
-        reader.seek(SeekFrom::Start(0))?;
+        reader.rewind()?;
 
         // Size of metadata + optional compression options metadata block
         let mut superblock = [0u8; 96];

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::io::{Seek, Write};
-use std::os::unix::prelude::OsStrExt;
 use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
@@ -121,8 +120,8 @@ impl<'a, 'b> TreeNode<'a, 'b> {
         inode_writer: &'_ mut MetadataWriter,
         dir_writer: &'_ mut MetadataWriter,
         data_writer: &'_ mut DataWriter,
+        parent_inode: u32,
     ) -> Result<(Entry, u64), SquashfsError> {
-        let parent_inode = *inode_counter;
         *inode_counter += 1;
         let this_inode = *inode_counter;
 
@@ -163,6 +162,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
                             inode_writer,
                             dir_writer,
                             data_writer,
+                            this_inode,
                         )
                         .map(|res| res.0) // only entry
                     })

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,7 +5,7 @@ use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
 use deku::DekuContainerWrite;
-use tracing::trace;
+use tracing::{instrument, trace};
 
 use crate::data::DataWriter;
 use crate::entry::Entry;
@@ -127,7 +127,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
     /// This works my recursively creating Inodes and Dirs for each node in the tree. This also
     /// keeps track of parent directories by calling this function on all nodes of a dir to get only
     /// the nodes, but going into the child dirs in the case that it contains a child dir.
-    //#[instrument(skip_all)]
+    #[instrument(skip_all)]
     #[allow(clippy::type_complexity)]
     pub fn write<W: Write + Seek>(
         &'b self,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -95,7 +95,6 @@ impl<'a, 'b> TreeNode<'a, 'b> {
             //this file already exists
             (true, Some(_file)) => {
                 //TODO directory is allowed to be duplicated??? ignore the second file?
-                ()
             },
             //this file don't exist in this dir, add it
             (true, None) => {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -174,7 +174,6 @@ impl<'a, 'b> TreeNode<'a, 'b> {
 
         // write child inodes
         for node in dir.values().filter(|c| !c.have_children()) {
-            let node_path = PathBuf::from(node.name());
             let entry = match &node.inner {
                 InnerTreeNode::Dir(path, _) => Entry::path(
                     node.name(),
@@ -187,7 +186,7 @@ impl<'a, 'b> TreeNode<'a, 'b> {
                     dir_writer.metadata_start,
                 ),
                 InnerTreeNode::File(file) => Entry::file(
-                    &node_path,
+                    node.name(),
                     file,
                     writer,
                     *inode_counter,
@@ -195,13 +194,13 @@ impl<'a, 'b> TreeNode<'a, 'b> {
                     inode_writer,
                 ),
                 InnerTreeNode::Symlink(symlink) => {
-                    Entry::symlink(&node_path, symlink, *inode_counter, inode_writer)
+                    Entry::symlink(node.name(), symlink, *inode_counter, inode_writer)
                 },
                 InnerTreeNode::CharacterDevice(char) => {
-                    Entry::char(&node_path, char, *inode_counter, inode_writer)
+                    Entry::char(node.name(), char, *inode_counter, inode_writer)
                 },
                 InnerTreeNode::BlockDevice(block) => {
-                    Entry::block_device(&node_path, block, *inode_counter, inode_writer)
+                    Entry::block_device(node.name(), block, *inode_counter, inode_writer)
                 },
             };
             write_entries.push(entry);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,10 @@ use std::ffi::OsStr;
 use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
-use crate::filesystem::{FilesystemWriter, InnerNode, SquashfsFileWriter};
+use crate::filesystem::{
+    FilesystemWriter, InnerNode, SquashfsBlockDevice, SquashfsCharacterDevice, SquashfsDir,
+    SquashfsFileWriter, SquashfsSymlink,
+};
 
 fn normalized_components(path: &Path) -> Vec<&OsStr> {
     let mut v = Vec::new();
@@ -26,8 +29,16 @@ fn normalized_components(path: &Path) -> Vec<&OsStr> {
 #[derive(Debug)]
 pub(crate) struct TreeNode<'a, 'b> {
     pub fullpath: PathBuf,
-    pub node: Option<&'b InnerNode<SquashfsFileWriter<'a>>>,
-    pub children: BTreeMap<PathBuf, TreeNode<'a, 'b>>,
+    pub inner: InnerTreeNode<'a, 'b>,
+}
+
+#[derive(Debug)]
+pub(crate) enum InnerTreeNode<'a, 'b> {
+    File(&'b SquashfsFileWriter<'a>),
+    Symlink(&'b SquashfsSymlink),
+    Dir(&'b SquashfsDir, BTreeMap<PathBuf, TreeNode<'a, 'b>>),
+    CharacterDevice(&'b SquashfsCharacterDevice),
+    BlockDevice(&'b SquashfsBlockDevice),
 }
 
 impl<'a, 'b> TreeNode<'a, 'b> {
@@ -39,26 +50,55 @@ impl<'a, 'b> TreeNode<'a, 'b> {
         }
     }
 
+    pub(crate) fn from_inner_node(
+        fullpath: PathBuf,
+        inner_node: &'b InnerNode<SquashfsFileWriter<'a>>,
+    ) -> Self {
+        let inner = match inner_node {
+            InnerNode::File(file) => InnerTreeNode::File(file),
+            InnerNode::Symlink(sym) => InnerTreeNode::Symlink(sym),
+            InnerNode::Dir(dir) => InnerTreeNode::Dir(dir, BTreeMap::new()),
+            InnerNode::CharacterDevice(char) => InnerTreeNode::CharacterDevice(char),
+            InnerNode::BlockDevice(block) => InnerTreeNode::BlockDevice(block),
+        };
+        Self { fullpath, inner }
+    }
+
     fn insert(
         &mut self,
         fullpath: &mut PathBuf,
         components: &[&OsStr],
         og_node: &'b InnerNode<SquashfsFileWriter<'a>>,
     ) {
-        if let Some((first, rest)) = components.split_first() {
-            fullpath.push(first);
+        let (first, rest) = match components {
+            [first, rest @ ..] => (first, rest),
+            _ => todo!("Error node have no name"),
+        };
+        fullpath.push(first);
+        let dir = match &mut self.inner {
+            InnerTreeNode::Dir(_, dir) => dir,
+            _ => todo!("Error node inside non-Dir"),
+        };
 
-            // no rest, we have the file
-            let node = rest.is_empty().then_some(og_node);
-            let entry = self
-                .children
-                .entry(fullpath.to_path_buf())
-                .or_insert(TreeNode {
-                    fullpath: fullpath.clone(),
-                    node,
-                    children: BTreeMap::new(),
-                });
-            entry.insert(fullpath, rest, og_node);
+        let is_file = rest.is_empty();
+        let children = dir.get_mut(fullpath);
+        match (is_file, children) {
+            //this file already exists
+            (true, Some(_file)) => {
+                //TODO directory is allowed to be duplicated???
+                //todo!("Error File already exists in the tree")
+            },
+            //this file don't exist in this dir, add it
+            (true, None) => {
+                dir.insert(
+                    fullpath.to_owned(),
+                    Self::from_inner_node(fullpath.to_owned(), og_node),
+                );
+            },
+            //not a file, dir, and it already exists
+            (false, Some(dir)) => dir.insert(fullpath, rest, og_node),
+            //not a file, dir, but the dir don't exits
+            _ => todo!("Error Dir don't exists"),
         }
     }
 }
@@ -67,8 +107,7 @@ impl<'a, 'b> From<&'b FilesystemWriter<'a>> for TreeNode<'a, 'b> {
     fn from(fs: &'b FilesystemWriter<'a>) -> Self {
         let mut tree = TreeNode {
             fullpath: "/".into(),
-            node: None,
-            children: BTreeMap::new(),
+            inner: InnerTreeNode::Dir(&fs.root_inode, BTreeMap::new()),
         };
         for node in &fs.nodes {
             let path = node.path.as_path();


### PR DESCRIPTION
This PR ended up being too big.

Now is possible to run https://github.com/wcampbell0x2a/backhand/pull/37.

The command `add airootfs.sfs empty-file /tmp`, takes around 6min and 1G of ram, but is at least possible.

The main memory saver is https://github.com/wcampbell0x2a/backhand/commit/3eb129d7eced3aa92a321715216e72643f548af4, that allow the buffered memory to be freed after the `FilesystemFileReader` is fully consumed.

But each commit saves few GB/MB of memory.