### PR TITLE
Define public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ backhand = "0.7.0"
 use std::cell::RefCell;
 use std::fs::File;
 use std::io::Cursor;
-use backhand::{FilesystemReader, FilesystemWriter, FilesystemHeader};
+use backhand::{FilesystemReader, FilesystemWriter, NodeHeader};
 
 // read
 let file = File::open("file.squashfs").unwrap();
@@ -34,7 +34,7 @@ let read_filesystem = FilesystemReader::from_reader(file).unwrap();
 let mut write_filesystem = FilesystemWriter::from_fs_reader(&read_filesystem).unwrap();
 
 // add file with data from slice
-let d = FilesystemHeader::default();
+let d = NodeHeader::default();
 let bytes = Cursor::new(b"Fear is the mind-killer.");
 write_filesystem.push_file(bytes, "a/d/e/new_file", d);
 

--- a/src/bin/add.rs
+++ b/src/bin/add.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-use backhand::filesystem::{FilesystemHeader, FilesystemReader, FilesystemWriter};
+use backhand::{FilesystemReader, FilesystemWriter, NodeHeader};
 use clap::Parser;
 
 /// tool to add files to squashfs filesystems
@@ -31,7 +31,7 @@ fn main() {
     // create new file
     let new_file = File::open(&args.file).unwrap();
     filesystem
-        .push_file(new_file, args.file_path, FilesystemHeader::default())
+        .push_file(new_file, args.file_path, NodeHeader::default())
         .unwrap();
 
     // write new file

--- a/src/bin/unsquashfs.rs
+++ b/src/bin/unsquashfs.rs
@@ -3,12 +3,10 @@ use std::io::Read;
 use std::os::unix::prelude::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use backhand::filesystem::{
-    FilesystemReader, InnerNode, SquashfsBlockDevice, SquashfsCharacterDevice, SquashfsDir,
-    SquashfsSymlink,
+use backhand::{
+    FilesystemReader, InnerNode, ReadSeek, Squashfs, SquashfsBlockDevice, SquashfsCharacterDevice,
+    SquashfsDir, SquashfsSymlink,
 };
-use backhand::reader::ReadSeek;
-use backhand::Squashfs;
 use clap::Parser;
 use nix::sys::stat::{mknod, Mode, SFlag};
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -14,7 +14,7 @@ use crate::inode::{
     InodeInner,
 };
 use crate::metadata::MetadataWriter;
-use crate::FilesystemHeader;
+use crate::NodeHeader;
 
 #[derive(Clone)]
 pub(crate) struct Entry<'a> {
@@ -62,7 +62,7 @@ impl<'a> Entry<'a> {
     /// Write data and metadata for file node
     pub fn file(
         node_path: &'a OsStr,
-        header: &FilesystemHeader,
+        header: &NodeHeader,
         inode: u32,
         inode_writer: &mut MetadataWriter,
         file_size: usize,

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -10,7 +10,7 @@ pub(crate) const SIZE: usize =
 #[derive(Copy, Clone, Debug, PartialEq, Eq, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct Fragment {
-    pub(crate) start: u64,
-    pub(crate) size: DataSize,
-    pub(crate) unused: u32,
+    pub start: u64,
+    pub size: DataSize,
+    pub unused: u32,
 }

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -9,7 +9,7 @@ use deku::prelude::*;
 use crate::data::DataSize;
 use crate::dir::DirectoryIndex;
 use crate::entry::Entry;
-use crate::filesystem::FilesystemHeader;
+use crate::filesystem::NodeHeader;
 use crate::metadata::MetadataWriter;
 
 #[derive(Debug, DekuRead, DekuWrite, Clone, PartialEq, Eq)]
@@ -94,8 +94,8 @@ pub struct InodeHeader {
     pub inode_number: u32,
 }
 
-impl From<FilesystemHeader> for InodeHeader {
-    fn from(fs_header: FilesystemHeader) -> Self {
+impl From<NodeHeader> for InodeHeader {
+    fn from(fs_header: NodeHeader) -> Self {
         Self {
             permissions: fs_header.permissions,
             uid: fs_header.uid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,7 @@
 //! # use std::cell::RefCell;
 //! # use std::fs::File;
 //! # use std::io::Cursor;
-//! # use backhand::{FilesystemReader, FilesystemWriter, FilesystemHeader};
-//!
+//! # use backhand::{FilesystemReader, FilesystemWriter, NodeHeader};
 //! // read
 //! let file = File::open("file.squashfs").unwrap();
 //! let read_filesystem = FilesystemReader::from_reader(file).unwrap();
@@ -29,7 +28,7 @@
 //! let mut write_filesystem = FilesystemWriter::from_fs_reader(&read_filesystem).unwrap();
 //!
 //! // add file with data from slice
-//! let d = FilesystemHeader::default();
+//! let d = NodeHeader::default();
 //! let bytes = Cursor::new(b"Fear is the mind-killer.");
 //! write_filesystem.push_file(bytes, "a/d/e/new_file", d);
 //!
@@ -51,18 +50,34 @@
 #[doc = include_str!("../README.md")]
 type _ReadmeTest = ();
 
-pub mod compressor;
+mod compressor;
 mod data;
-pub mod dir;
+mod dir;
 mod entry;
-pub mod error;
-pub mod filesystem;
-pub mod fragment;
-pub mod inode;
+mod error;
+mod filesystem;
+mod fragment;
+mod inode;
 mod metadata;
-pub mod reader;
-pub mod squashfs;
+mod reader;
+mod squashfs;
 mod tree;
 
-pub use crate::filesystem::{FilesystemHeader, FilesystemReader, FilesystemWriter};
+pub use crate::filesystem::{
+    FilesystemReader, FilesystemWriter, InnerNode, NodeHeader, SquashfsBlockDevice,
+    SquashfsCharacterDevice, SquashfsDir, SquashfsFileReader, SquashfsFileWriter, SquashfsSymlink,
+};
+pub use crate::reader::ReadSeek;
 pub use crate::squashfs::Squashfs;
+
+/// Compression Choice and Options
+pub mod compression {
+    pub use crate::compressor::{CompressionOptions, Compressor, Gzip, Lz4, Lzo, Xz, Zstd};
+}
+
+/// [`Squashfs`] internal structs
+pub mod internal {
+    pub use crate::fragment::Fragment;
+    pub use crate::inode::Inode;
+    pub use crate::squashfs::{Export, Id, SuperBlock};
+}

--- a/tests/mutate.rs
+++ b/tests/mutate.rs
@@ -2,8 +2,7 @@ mod common;
 use std::fs::File;
 use std::io::Cursor;
 
-use backhand::filesystem::{FilesystemHeader, FilesystemReader};
-use backhand::FilesystemWriter;
+use backhand::{FilesystemReader, FilesystemWriter, NodeHeader};
 use common::test_unsquashfs;
 use test_assets::TestAssetDef;
 use test_log::test;
@@ -58,7 +57,7 @@ fn test_add_00() {
     let og_filesystem = FilesystemReader::from_reader(file).unwrap();
     let mut new_filesystem = FilesystemWriter::from_fs_reader(&og_filesystem).unwrap();
 
-    let h = FilesystemHeader {
+    let h = NodeHeader {
         permissions: 0o755,
         uid: 0,
         gid: 0,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,7 @@
 mod common;
 use std::fs::File;
 
-use backhand::filesystem::FilesystemReader;
-use backhand::FilesystemWriter;
+use backhand::{FilesystemReader, FilesystemWriter};
 use common::{test_unsquashfs, test_unsquashfs_list};
 use test_assets::TestAssetDef;
 use test_log::test;


### PR DESCRIPTION
- All public API is defined within the lib.rs, with previous modules being hidden by default
- Rename FilesysteHeader into NodeHeader