### PR TITLE
Add some types to public API

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -78,6 +78,7 @@ impl<R: ReadSeek> FilesystemReader<R> {
     }
 }
 
+/// Filesystem handle for file
 #[derive(Copy)]
 pub struct FilesystemReaderFile<'a, R: ReadSeek> {
     pub(crate) system: &'a FilesystemReader<R>,
@@ -722,7 +723,7 @@ impl From<InodeHeader> for NodeHeader {
     }
 }
 
-/// Nodes from an existing file that are converted into filesystem tree during writing to bytes
+/// Filesystem Node
 #[derive(Debug, PartialEq, Eq)]
 pub struct Node<T> {
     pub path: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,9 @@ mod squashfs;
 mod tree;
 
 pub use crate::filesystem::{
-    FilesystemReader, FilesystemWriter, InnerNode, NodeHeader, SquashfsBlockDevice,
-    SquashfsCharacterDevice, SquashfsDir, SquashfsFileReader, SquashfsFileWriter, SquashfsSymlink,
+    FilesystemReader, FilesystemReaderFile, FilesystemWriter, InnerNode, Node, NodeHeader,
+    SquashfsBlockDevice, SquashfsCharacterDevice, SquashfsDir, SquashfsFileReader,
+    SquashfsFileSource, SquashfsFileWriter, SquashfsSymlink,
 };
 pub use crate::reader::ReadSeek;
 pub use crate::squashfs::Squashfs;


### PR DESCRIPTION
Some types further down in the API weren't public, this makes them
public: FilesystemReaderFile and Node.