### PR TITLE
Fix FilesystemWriter::push_file(..), Remove Return Types, Rel v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.8.2] - 2023-02-13
+-  `FilesystemWriter::push_file(..)` correctly enters file into filesystem
+
 ## [v0.8.1] - 2023-02-11
 - Fix `src/lib.rs` version for docs.rs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [v0.8.2] - 2023-02-13
--  `FilesystemWriter::push_file(..)` correctly enters file into filesystem
+## [v0.9.0] - 2023-02-13
+### Fixed
+- `FilesystemWriter::push_file(..)` correctly enters file into filesystem
+### Changed
+- Remove Result return type from `FilesystemWriter::{push_file(..), push_dir(..), push_symlink(..), push_char_device(..) and push_block_devivce(..)`.
+- Remove unused errors: `FieldNotInitialized` and `OsStringToStr`.
 
 ## [v0.8.1] - 2023-02-11
 - Fix `src/lib.rs` version for docs.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backhand"
 repository = "https://github.com/wcampbell0x2a/backhand"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.64.0"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backhand"
 repository = "https://github.com/wcampbell0x2a/backhand"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 rust-version = "1.64.0"
 license = "MIT/Apache-2.0"

--- a/src/bin/add.rs
+++ b/src/bin/add.rs
@@ -30,9 +30,7 @@ fn main() {
 
     // create new file
     let new_file = File::open(&args.file).unwrap();
-    filesystem
-        .push_file(new_file, args.file_path, NodeHeader::default())
-        .unwrap();
+    filesystem.push_file(new_file, args.file_path, NodeHeader::default());
 
     // write new file
     let mut output = File::create("added.squashfs").unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,12 +27,6 @@ pub enum SquashfsError {
     #[error("file not found")]
     FileNotFound,
 
-    #[error("squashfs field not initialized")]
-    FieldNotInitialized,
-
-    #[error("os string cannot convert into str")]
-    OsStringToStr,
-
     #[error("branch was thought to be unreachable")]
     Unreachable,
 
@@ -54,8 +48,6 @@ impl From<SquashfsError> for io::Error {
                 Self::new(io::ErrorKind::Unsupported, e)
             },
             e @ SquashfsError::FileNotFound => Self::new(io::ErrorKind::NotFound, e),
-            e @ SquashfsError::FieldNotInitialized => Self::new(io::ErrorKind::InvalidData, e),
-            e @ SquashfsError::OsStringToStr => Self::new(io::ErrorKind::InvalidData, e),
             e @ SquashfsError::Unreachable => Self::new(io::ErrorKind::InvalidData, e),
             e @ SquashfsError::UnexpectedInode(_) => Self::new(io::ErrorKind::InvalidData, e),
             e @ SquashfsError::UnsupportedInode(_) => Self::new(io::ErrorKind::InvalidData, e),

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -426,7 +426,7 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         reader: impl Read + 'a,
         path: P,
         header: NodeHeader,
-    ) -> Result<(), SquashfsError> {
+    ) {
         let path = path.into();
 
         if path.parent().is_some() {
@@ -461,8 +461,6 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         });
         let node = Node::new(path, new_file);
         self.nodes.push(node);
-
-        Ok(())
     }
 
     /// Take a mutable reference to existing file at `find_path`
@@ -502,7 +500,7 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         link: S,
         path: P,
         header: NodeHeader,
-    ) -> Result<(), SquashfsError> {
+    ) {
         let path = path.into();
 
         let new_symlink = InnerNode::Symlink(SquashfsSymlink {
@@ -511,23 +509,15 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         });
         let node = Node::new(path, new_symlink);
         self.nodes.push(node);
-
-        Ok(())
     }
 
     /// Insert empty `dir` at `path`
-    pub fn push_dir<P: Into<PathBuf>>(
-        &mut self,
-        path: P,
-        header: NodeHeader,
-    ) -> Result<(), SquashfsError> {
+    pub fn push_dir<P: Into<PathBuf>>(&mut self, path: P, header: NodeHeader) {
         let path = path.into();
 
         let new_dir = InnerNode::Dir(SquashfsDir { header });
         let node = Node::new(path, new_dir);
         self.nodes.push(node);
-
-        Ok(())
     }
 
     /// Insert character device with `device_number` at `path`
@@ -536,7 +526,7 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         device_number: u32,
         path: P,
         header: NodeHeader,
-    ) -> Result<(), SquashfsError> {
+    ) {
         let path = path.into();
 
         let new_device = InnerNode::CharacterDevice(SquashfsCharacterDevice {
@@ -545,8 +535,6 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         });
         let node = Node::new(path, new_device);
         self.nodes.push(node);
-
-        Ok(())
     }
 
     /// Insert block device with `device_number` at `path`
@@ -555,7 +543,7 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         device_number: u32,
         path: P,
         header: NodeHeader,
-    ) -> Result<(), SquashfsError> {
+    ) {
         let path = path.into();
 
         let new_device = InnerNode::BlockDevice(SquashfsBlockDevice {
@@ -564,8 +552,6 @@ impl<'a, R: ReadSeek> FilesystemWriter<'a, R> {
         });
         let node = Node::new(path, new_device);
         self.nodes.push(node);
-
-        Ok(())
     }
 
     /// Generate the final squashfs file at the offset.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -104,7 +104,7 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
             //not a file, dir, and it already exists
             (false, Some(dir)) => dir.insert(rest, node),
             //not a file, dir, but the dir don't exits
-            _ => todo!("Error Dir don't exists"),
+            (false, None) => todo!("Error Dir don't exists"),
         }
     }
 

--- a/tests/mutate.rs
+++ b/tests/mutate.rs
@@ -67,21 +67,13 @@ fn test_add_00() {
 
     // Add file
     let bytes = Cursor::new(b"this is a new file, wowo!");
-    new_filesystem
-        .push_file(bytes, "a/d/e/new_file", h)
-        .unwrap();
+    new_filesystem.push_file(bytes, "a/d/e/new_file", h);
     // Add file
-    new_filesystem
-        .push_file(Cursor::new("i am (g)root"), "root_file", h)
-        .unwrap();
+    new_filesystem.push_file(Cursor::new("i am (g)root"), "root_file", h);
     // Add file
-    new_filesystem
-        .push_file(Cursor::new("dude"), "a/b/c/d/dude", h)
-        .unwrap();
+    new_filesystem.push_file(Cursor::new("dude"), "a/b/c/d/dude", h);
 
-    new_filesystem
-        .push_symlink("a/b/c/d/dude", "ptr", h)
-        .unwrap();
+    new_filesystem.push_symlink("a/b/c/d/dude", "ptr", h);
 
     // Modify file
     new_filesystem

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -1,5 +1,4 @@
 mod common;
-use std::path::PathBuf;
 
 use backhand::compression::Compressor;
 use backhand::internal::Id;
@@ -42,20 +41,18 @@ fn test_raw_00() {
         nodes: vec![],
     };
 
-    fs.push_dir("usr", o_header).unwrap();
-    fs.push_dir("usr/bin", o_header).unwrap();
+    fs.push_dir("usr", o_header);
+    fs.push_dir("usr/bin", o_header);
     fs.push_file(
         std::io::Cursor::new(vec![0x00, 0x01]),
         "usr/bin/heyo",
         header,
-    )
-    .unwrap();
+    );
     fs.push_file(
         std::io::Cursor::new(vec![0x0f; 0xff]),
         "this/is/a/file",
         header,
-    )
-    .unwrap();
+    );
 
     // create the modified squashfs
     let mut output = std::fs::File::create(&new_path).unwrap();

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -1,0 +1,67 @@
+mod common;
+use std::path::PathBuf;
+
+use backhand::compression::Compressor;
+use backhand::internal::Id;
+use backhand::{FilesystemWriter, NodeHeader, SquashfsDir};
+use common::test_unsquashfs;
+use test_assets::TestAssetDef;
+
+#[test]
+#[cfg(feature = "xz")]
+fn test_raw_00() {
+    let asset_defs = [TestAssetDef {
+        filename: "control.squashfs".to_string(),
+        hash: "a2970a4e82014740b2333f4555eecf321898633ccadb443affec966f47f3acb3".to_string(),
+        url: "wcampbell.dev/squashfs/testing/test_raw_00/control.squashfs".to_string(),
+    }];
+    const TEST_PATH: &str = "test-assets/test_raw_00";
+    let new_path = format!("{TEST_PATH}/bytes.squashfs");
+    test_assets::download_test_files(&asset_defs, TEST_PATH, true).unwrap();
+
+    let header = NodeHeader {
+        permissions: 0o755,
+        uid: 0,
+        gid: 0,
+        mtime: 0,
+    };
+
+    let o_header = NodeHeader {
+        permissions: 0o766,
+        ..header
+    };
+
+    let mut fs: FilesystemWriter = FilesystemWriter {
+        id_table: Some(vec![Id(0)]),
+        mod_time: 0x634f5237,
+        block_size: 0x040000,
+        compressor: Compressor::Xz,
+        compression_options: None,
+        block_log: 0x000012,
+        root_inode: SquashfsDir { header },
+        nodes: vec![],
+    };
+
+    fs.push_dir("usr", o_header).unwrap();
+    fs.push_dir("usr/bin", o_header).unwrap();
+    fs.push_file(
+        std::io::Cursor::new(vec![0x00, 0x01]),
+        "usr/bin/heyo",
+        header,
+    )
+    .unwrap();
+    fs.push_file(
+        std::io::Cursor::new(vec![0x0f; 0xff]),
+        "this/is/a/file",
+        header,
+    )
+    .unwrap();
+
+    // create the modified squashfs
+    let mut output = std::fs::File::create(&new_path).unwrap();
+    fs.write(&mut output).unwrap();
+
+    // compare
+    let control_new_path = format!("{TEST_PATH}/control.squashfs");
+    test_unsquashfs(&new_path, &control_new_path, None);
+}


### PR DESCRIPTION
### Fixed
- `FilesystemWriter::push_file(..)` correctly enters file into filesystem
### Changed
- Remove Result return type from `FilesystemWriter::{push_file(..), push_dir(..), push_symlink(..), push_char_device(..) and push_block_devivce(..)`.
- Remove unused errors: `FieldNotInitialized` and `OsStringToStr`.

