### PR TITLE
Use latest xz2 to support arm filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ deku = "0.15.0"
 tracing = "0.1.37"
 thiserror = "1.0.37"
 flate2 = { version = "1.0.24", optional = true }
-xz2 = { version = "0.1.7", optional = true }
+xz2 = { git = "https://github.com/wcampbell0x2a/xz2-rs", branch = "add-arm-decoder-encoders", optional = true }
 rustc-hash = "1.1.0"
 
 # for bins

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -224,7 +224,6 @@ fn test_openwrt_tplink_archera7v5() {
 
 #[test]
 #[cfg(feature = "xz")]
-#[cfg(not(feature = "xz-static"))]
 fn test_openwrt_netgear_ex6100v2() {
     const FILE_NAME: &str = "openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img";
 
@@ -269,7 +268,6 @@ fn test_appimage_firefox() {
 /// (after ubi_extract_image)
 #[test]
 #[cfg(feature = "xz")]
-#[cfg(not(feature = "xz-static"))]
 fn test_tplink_ax1800() {
     const FILE_NAME: &str = "img-1571203182_vol-ubi_rootfs.ubifs";
     let asset_defs = [TestAssetDef {


### PR DESCRIPTION
- These are used in the openwrt netgear and tplink ax1800

See #150 