### PR TITLE
Pass filesystem BlockFragment by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed many issues found with fuzz testing related to legal images.
   Checks are now added at every stop possible to prevent many soundness issues.
+### Changed
+- Pass internal raw data by reference, improving `only_read` benchmarks by ~9%.
 
 ## [v0.9.1] - 2023-02-16
 ### Fixed

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -173,7 +173,7 @@ impl<'a, R: ReadSeek> SquashfsRawData<'a, R> {
     fn read_raw_data(
         &mut self,
         data: &mut Vec<u8>,
-        block: BlockFragment<'a>,
+        block: &BlockFragment<'a>,
     ) -> Result<RawDataBlock, SquashfsError> {
         match block {
             BlockFragment::Block(block) => {
@@ -220,7 +220,7 @@ impl<'a, R: ReadSeek> SquashfsRawData<'a, R> {
     pub fn next_block(&mut self, buf: &mut Vec<u8>) -> Option<Result<RawDataBlock, SquashfsError>> {
         self.current_block
             .next()
-            .map(|next| self.read_raw_data(buf, next))
+            .map(|next| self.read_raw_data(buf, &next))
     }
     fn fragment_range(&self) -> std::ops::Range<usize> {
         let block_len = self.file.system.block_size as usize;


### PR DESCRIPTION
- Around 9% improvement in read_only benchmarks