### PR TITLE
WIP: Support non-standard images

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -11,9 +11,11 @@ use std::path::PathBuf;
 use deku::prelude::*;
 
 use crate::inode::InodeId;
+use crate::kind::Kind;
 
 #[derive(Debug, DekuRead, DekuWrite, Clone, Default, PartialEq, Eq)]
-#[deku(endian = "little")]
+#[deku(ctx = "kind: Kind")]
+#[deku(endian = "kind.type_endian")]
 pub struct Dir {
     /// Number of entries following the header.
     pub(crate) count: u32,

--- a/src/filesystem/reader.rs
+++ b/src/filesystem/reader.rs
@@ -7,12 +7,13 @@ use crate::error::SquashfsError;
 use crate::fragment::Fragment;
 use crate::inode::BasicFile;
 use crate::reader::{ReadSeek, SquashfsReaderWithOffset};
-use crate::squashfs::{Cache, Id};
+use crate::squashfs::{Cache, Id, Kind};
 use crate::{Node, Squashfs, SquashfsDir, SquashfsFileReader};
 
 /// Representation of SquashFS filesystem after read from image
 #[derive(Debug)]
 pub struct FilesystemReader<R: ReadSeek> {
+    pub kind: Kind,
     /// See [`SuperBlock`].`block_size`
     pub block_size: u32,
     /// See [`SuperBlock`].`block_log`
@@ -39,6 +40,8 @@ pub struct FilesystemReader<R: ReadSeek> {
 
 impl<R: ReadSeek> FilesystemReader<R> {
     /// Call [`Squashfs::from_reader`], then [`Squashfs::into_filesystem_reader`]
+    ///
+    /// With default kind: [`crate::kind::LE_V4_0`] and offset `0`.
     pub fn from_reader(reader: R) -> Result<Self, SquashfsError> {
         let squashfs = Squashfs::from_reader(reader)?;
         squashfs.into_filesystem_reader()
@@ -49,6 +52,16 @@ impl<R: ReadSeek> FilesystemReader<SquashfsReaderWithOffset<R>> {
     /// Same as [`Self::from_reader`], but seek'ing to `offset` in `reader` before reading
     pub fn from_reader_with_offset(reader: R, offset: u64) -> Result<Self, SquashfsError> {
         let squashfs = Squashfs::from_reader_with_offset(reader, offset)?;
+        squashfs.into_filesystem_reader()
+    }
+
+    /// Same as [`Self::from_reader_with_offset`], but setting custom `kind`
+    pub fn from_reader_with_offset_and_kind(
+        reader: R,
+        offset: u64,
+        kind: Kind,
+    ) -> Result<Self, SquashfsError> {
+        let squashfs = Squashfs::from_reader_with_offset_and_kind(reader, offset, kind)?;
         squashfs.into_filesystem_reader()
     }
 }

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -3,12 +3,13 @@
 use deku::prelude::*;
 
 use crate::data::DataSize;
+use crate::kind::Kind;
 
 pub(crate) const SIZE: usize =
     std::mem::size_of::<u64>() + std::mem::size_of::<u32>() + std::mem::size_of::<u32>();
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, DekuRead, DekuWrite)]
-#[deku(endian = "little")]
+#[deku(endian = "kind.type_endian", ctx = "kind: Kind")]
 pub struct Fragment {
     pub start: u64,
     pub size: DataSize,

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -9,13 +9,14 @@ use deku::prelude::*;
 use crate::data::DataSize;
 use crate::dir::DirectoryIndex;
 use crate::entry::Entry;
+use crate::kind::Kind;
 use crate::metadata::MetadataWriter;
 use crate::squashfs::SuperBlock;
 use crate::NodeHeader;
 
 #[derive(Debug, DekuRead, DekuWrite, Clone, PartialEq, Eq)]
-#[deku(ctx = "bytes_used: u64, block_size: u32, block_log: u16")]
-#[deku(endian = "little")]
+#[deku(ctx = "bytes_used: u64, block_size: u32, block_log: u16, kind: Kind")]
+#[deku(endian = "kind.type_endian")]
 pub struct Inode {
     pub id: InodeId,
     pub header: InodeHeader,
@@ -30,6 +31,7 @@ impl Inode {
         name: &'a [u8],
         m_writer: &mut MetadataWriter,
         superblock: &SuperBlock,
+        kind: Kind,
     ) -> Entry<'a> {
         let mut v = BitVec::<u8, Msb0>::new();
         self.write(
@@ -38,6 +40,7 @@ impl Inode {
                 0xffff_ffff_ffff_ffff, // bytes_used is unused for ctx. set to max
                 superblock.block_size,
                 superblock.block_log,
+                kind,
             ),
         )
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,11 @@ pub use crate::filesystem::writer::FilesystemWriter;
 pub use crate::reader::ReadSeek;
 pub use crate::squashfs::Squashfs;
 
+/// Support the wonderful world of vendor formats
+pub mod kind {
+    pub use crate::squashfs::{Endian, Kind, Magic, AVM_BE_V4_0, BE_V4_0, LE_V4_0};
+}
+
 /// Compression Choice and Options
 pub mod compression {
     pub use crate::compressor::{CompressionOptions, Compressor, Gzip, Lz4, Lzo, Xz, Zstd};

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,12 +4,14 @@ use std::io::Write;
 use std::path::Component::*;
 use std::path::{Path, PathBuf};
 
-use deku::DekuContainerWrite;
+use deku::bitvec::BitVec;
+use deku::prelude::*;
 use tracing::trace;
 
 use crate::data::{Added, DataWriter};
 use crate::entry::Entry;
 use crate::error::SquashfsError;
+use crate::kind::Kind;
 use crate::metadata::MetadataWriter;
 use crate::reader::{ReadSeek, WriteSeek};
 use crate::squashfs::SuperBlock;
@@ -176,6 +178,7 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
         dir_writer: &'_ mut MetadataWriter,
         parent_inode: u32,
         superblock: SuperBlock,
+        kind: Kind,
     ) -> Result<(Option<Entry>, u64), SquashfsError> {
         // If no children, just return since it doesn't have anything recursive/new
         // directories
@@ -198,7 +201,7 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
         // tree has children, this is a Dir, get information of every child node
         for child in dir.values() {
             let (l_dir_entries, _) =
-                child.write_inode_dir(inode_writer, dir_writer, this_inode, superblock)?;
+                child.write_inode_dir(inode_writer, dir_writer, this_inode, superblock, kind)?;
             if let Some(entry) = l_dir_entries {
                 write_entries.push(entry);
             }
@@ -217,6 +220,7 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
                     dir_writer.uncompressed_bytes.len() as u16,
                     dir_writer.metadata_start,
                     &superblock,
+                    kind,
                 ),
                 InnerTreeNode::FilePhase2(filesize, added, header) => Entry::file(
                     node.name(),
@@ -226,6 +230,7 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
                     *filesize,
                     added,
                     &superblock,
+                    kind,
                 ),
                 InnerTreeNode::Symlink(symlink) => Entry::symlink(
                     node.name(),
@@ -233,16 +238,23 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
                     node.inode_id,
                     inode_writer,
                     &superblock,
+                    kind,
                 ),
-                InnerTreeNode::CharacterDevice(char) => {
-                    Entry::char(node.name(), char, node.inode_id, inode_writer, &superblock)
-                },
+                InnerTreeNode::CharacterDevice(char) => Entry::char(
+                    node.name(),
+                    char,
+                    node.inode_id,
+                    inode_writer,
+                    &superblock,
+                    kind,
+                ),
                 InnerTreeNode::BlockDevice(block) => Entry::block_device(
                     node.name(),
                     block,
                     node.inode_id,
                     inode_writer,
                     &superblock,
+                    kind,
                 ),
                 InnerTreeNode::FilePhase1(_) => unreachable!(),
             };
@@ -256,9 +268,13 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
         let mut total_size = 3;
         for dir in Entry::into_dir(write_entries) {
             trace!("WRITING DIR: {dir:#02x?}");
-            let bytes = dir.to_bytes()?;
+
+            let mut bv = BitVec::new();
+            dir.write(&mut bv, kind)?;
+            let bytes = bv.as_raw_slice();
+            dir_writer.write_all(bv.as_raw_slice())?;
+
             total_size += bytes.len() as u16;
-            dir_writer.write_all(&bytes)?;
         }
 
         //trace!("BEFORE: {:#02x?}", child);
@@ -272,6 +288,7 @@ impl<'a, 'b, R: ReadSeek> TreeNode<'a, 'b, R> {
             block_offset,
             block_index,
             &superblock,
+            kind,
         );
         let root_inode = ((entry.start as u64) << 16) | ((entry.offset as u64) & 0xffff);
 

--- a/tests/non_standard.rs
+++ b/tests/non_standard.rs
@@ -1,0 +1,81 @@
+mod common;
+use std::fs::File;
+
+use backhand::kind::{self, Kind};
+use backhand::{FilesystemReader, FilesystemWriter};
+use test_assets::TestAssetDef;
+use test_log::test;
+use tracing::info;
+
+/// - Download file
+/// - Read into Squashfs
+/// - Into Filesystem
+/// - Into Bytes
+/// - - Into Squashfs
+/// - - Into Filesystem
+/// - Can't test with unsquashfs, as it doesn't support these custom filesystems
+fn full_test(
+    assets_defs: &[TestAssetDef],
+    filepath: &str,
+    test_path: &str,
+    offset: u64,
+    kind: Kind,
+) {
+    test_assets::download_test_files(assets_defs, test_path, true).unwrap();
+
+    let og_path = format!("{test_path}/{filepath}");
+    let new_path = format!("{test_path}/bytes.squashfs");
+    let file = File::open(og_path).unwrap();
+    info!("calling from_reader");
+    let og_filesystem =
+        FilesystemReader::from_reader_with_offset_and_kind(file, offset, kind).unwrap();
+    let new_filesystem = FilesystemWriter::from_fs_reader(&og_filesystem).unwrap();
+
+    // convert to bytes
+    info!("calling to_bytes");
+    let mut output = File::create(&new_path).unwrap();
+    new_filesystem
+        .write_with_offset(&mut output, offset)
+        .unwrap();
+
+    // Test Debug is impl'ed properly on FilesystemWriter
+    let _ = format!("{new_filesystem:#02x?}");
+
+    // assert that our library can atleast read the output
+    info!("calling from_reader");
+    let created_file = File::open(&new_path).unwrap();
+    let _new_filesystem =
+        FilesystemReader::from_reader_with_offset_and_kind(created_file, offset, kind).unwrap();
+}
+
+#[test]
+#[cfg(feature = "gzip")]
+fn test_non_standard_be_v4_0() {
+    const FILE_NAME: &str = "squashfs_v4.bin";
+    let asset_defs = [TestAssetDef {
+        filename: FILE_NAME.to_string(),
+        hash: "9c7c523c5d1d1cafc0b679af9092ce0289d9656f6a24bc3bd0009f95b69397c0".to_string(),
+        url: "https://github.com/onekey-sec/unblob/raw/3c7e886e2616413a4d6109ba3d197f91c9596881/tests/integration/filesystem/squashfs/squashfs_v4_be/__input__/squashfs_v4.bin".to_string(),
+    }];
+    const TEST_PATH: &str = "test-assets/non_standard_be_v4_0";
+    full_test(&asset_defs, FILE_NAME, TEST_PATH, 0, kind::BE_V4_0);
+
+    // test custom kind "builder-lite"
+    let kind = Kind::new()
+        .with_magic(kind::Magic::Big)
+        .with_all_endian(kind::Endian::Big);
+    assert_eq!(kind, kind::BE_V4_0);
+}
+
+#[test]
+#[cfg(feature = "gzip")]
+fn test_non_standard_be_v4_1() {
+    const FILE_NAME: &str = "squashfs_v4.nopad.bin";
+    let asset_defs = [TestAssetDef {
+        filename: FILE_NAME.to_string(),
+        hash: "a29ddc15f5a6abcabf28b7161837eb56b34111e48420e7392e648f2fdfe956ed".to_string(),
+        url: "https://github.com/onekey-sec/unblob/raw/3c7e886e2616413a4d6109ba3d197f91c9596881/tests/integration/filesystem/squashfs/squashfs_v4_be/__input__/squashfs_v4.nopad.bin".to_string(),
+    }];
+    const TEST_PATH: &str = "test-assets/non_standard_be_v4_1";
+    full_test(&asset_defs, FILE_NAME, TEST_PATH, 0, kind::BE_V4_0);
+}

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -2,7 +2,7 @@ mod common;
 
 use backhand::compression::Compressor;
 use backhand::internal::Id;
-use backhand::{FilesystemWriter, NodeHeader, SquashfsDir};
+use backhand::{kind, FilesystemWriter, NodeHeader, SquashfsDir};
 use common::test_unsquashfs;
 use test_assets::TestAssetDef;
 
@@ -31,12 +31,13 @@ fn test_raw_00() {
     };
 
     let mut fs: FilesystemWriter = FilesystemWriter {
-        id_table: Some(vec![Id(0)]),
-        mod_time: 0x634f5237,
-        block_size: 0x040000,
+        kind: kind::LE_V4_0,
+        block_size: 0x0004_0000,
+        block_log: 0x0000_0012,
         compressor: Compressor::Xz,
         compression_options: None,
-        block_log: 0x000012,
+        mod_time: 0x634f_5237,
+        id_table: Some(vec![Id(0)]),
         root_inode: SquashfsDir { header },
         nodes: vec![],
     };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -224,7 +224,13 @@ fn test_openwrt_tplink_archera7v5() {
         ),
     }];
     const TEST_PATH: &str = "test-assets/test_openwrt_tplink_archera7v5";
-    full_test(&asset_defs, FILE_NAME, TEST_PATH, 0x225fd0, Verify::Extract);
+    full_test(
+        &asset_defs,
+        FILE_NAME,
+        TEST_PATH,
+        0x0022_5fd0,
+        Verify::Extract,
+    );
 }
 
 #[test]
@@ -241,7 +247,13 @@ fn test_openwrt_netgear_ex6100v2() {
         ),
     }];
     const TEST_PATH: &str = "test-assets/test_openwrt_netgear_ex6100v2";
-    full_test(&asset_defs, FILE_NAME, TEST_PATH, 0x2c0080, Verify::Extract);
+    full_test(
+        &asset_defs,
+        FILE_NAME,
+        TEST_PATH,
+        0x002c_0080,
+        Verify::Extract,
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Support non standard images. Read and Write!
- Add Kind for including endian and version information
- Add Kind: LE_V4_0 for linux kernel and upstream squashfs-tools support
- Add Kind: BE_V4_0 for custom vendor firmware
- Add Kind: AVM_BE_V4_0 for Fritz!OS firmware support. Added because it's interesting, as they kept some of it still BE.
- Change lookup table from u32 to u64. This was working in LE, but is
  very wrong for LE!

See https://github.com/wcampbell0x2a/backhand/issues/72