### PR TITLE
Add set_kib_padding to FilesystemWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `LE_V4_0`: (linux kernel) Little-Endian default official v4.0
     - `BE_V4_0`: Big-Endian v4.0
     - `AVM_BE_V4_0`: AVM Fritz!OS firmware support.
-- `FilesystemWriter`: Builder pattern used when mutating an image
+- `FilesystemWriter`: Builder pattern used when mutating an image. This includes multiple functions
+   for the public API. Supporting both raw images and modification made to images that already exist.
 - `FilesytemCompressor`: `.compressor` is now `FilesystemCompressor`,
    which holds the Id as well as options stored in the image as well as extra options only used when
    compressing when creating a new image.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,8 @@ pub use crate::fragment::Fragment;
 pub use crate::inode::Inode;
 pub use crate::reader::ReadSeek;
 pub use crate::squashfs::{
-    Export, Id, Squashfs, SuperBlock, DEFAULT_BLOCK_SIZE, MAX_BLOCK_SIZE, MIN_BLOCK_SIZE,
+    Export, Id, Squashfs, SuperBlock, DEFAULT_BLOCK_SIZE, DEFAULT_PAD_LEN, MAX_BLOCK_SIZE,
+    MIN_BLOCK_SIZE,
 };
 
 /// Support the wonderful world of vendor formats

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -25,6 +25,9 @@ use crate::{
 /// 128KiB
 pub const DEFAULT_BLOCK_SIZE: u32 = 0x20000;
 
+/// 4KiB
+pub const DEFAULT_PAD_LEN: u32 = 0x1000;
+
 /// log2 of 128KiB
 const DEFAULT_BLOCK_LOG: u16 = 0x11;
 
@@ -190,7 +193,7 @@ impl Id {
 }
 
 /// Contains important information about the archive, including the locations of other sections
-#[derive(Debug, Copy, Clone, DekuRead, DekuWrite)]
+#[derive(Debug, Copy, Clone, DekuRead, DekuWrite, PartialEq, Eq)]
 #[deku(endian = "kind.type_endian", ctx = "kind: Kind")]
 pub struct SuperBlock {
     /// Must be set to 0x73717368 ("hsqs" on disk).

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -1,15 +1,16 @@
 mod common;
 
 use backhand::compression::Compressor;
-use backhand::{kind, FilesystemWriter, NodeHeader};
+use backhand::{
+    kind, CompressionExtra, ExtraXz, FilesystemCompressor, FilesystemWriter, NodeHeader,
+    SuperBlock, DEFAULT_BLOCK_SIZE,
+};
 use common::test_unsquashfs;
 use test_assets::TestAssetDef;
 
 #[test]
 #[cfg(feature = "xz")]
 fn test_raw_00() {
-    use backhand::{CompressionExtra, ExtraXz, FilesystemCompressor, DEFAULT_BLOCK_SIZE};
-
     let asset_defs = [TestAssetDef {
         filename: "control.squashfs".to_string(),
         hash: "a2970a4e82014740b2333f4555eecf321898633ccadb443affec966f47f3acb3".to_string(),
@@ -39,14 +40,17 @@ fn test_raw_00() {
     let mut compressor = FilesystemCompressor::new(Compressor::Xz, None).unwrap();
     compressor.extra(extra).unwrap();
 
+    let time = 0x634f_5237;
+
     // (some of these are already set with default(), but just testing...)
     let mut fs = FilesystemWriter::default();
-    fs.set_time(0x634f_5237);
+    fs.set_time(time);
     fs.set_block_size(DEFAULT_BLOCK_SIZE);
     fs.set_only_root_id();
     fs.set_root_mode(0o777);
     fs.set_compressor(compressor);
     fs.set_kind(kind::LE_V4_0);
+    fs.set_kib_padding(8);
 
     fs.push_dir("usr", o_header);
     fs.push_dir("usr/bin", o_header);
@@ -63,7 +67,34 @@ fn test_raw_00() {
 
     // create the modified squashfs
     let mut output = std::fs::File::create(&new_path).unwrap();
-    fs.write(&mut output).unwrap();
+    let (superblock, bytes_written) = fs.write(&mut output).unwrap();
+
+    // 8KiB
+    assert_eq!(bytes_written, 0x2000);
+    assert_eq!(
+        superblock,
+        SuperBlock {
+            magic: [0x68, 0x73, 0x71, 0x73],
+            inode_count: 0x8,
+            mod_time: time,
+            block_size: 0x20000,
+            frag_count: 0x1,
+            compressor: Compressor::Xz,
+            block_log: 0x11,
+            flags: 0x0,
+            id_count: 0x1,
+            version_major: 0x4,
+            version_minor: 0x0,
+            root_inode: 0xe0,
+            bytes_used: 0x1ec,
+            id_table: 0x1e4,
+            xattr_table: 0xffffffffffffffff,
+            inode_table: 0xac,
+            dir_table: 0x136,
+            frag_table: 0x1d6,
+            export_table: 0xffffffffffffffff,
+        }
+    );
 
     // compare
     let control_new_path = format!("{TEST_PATH}/control.squashfs");


### PR DESCRIPTION
- Add pad_len to FilesystemWriter, with public API set_kib_padding
- Test bytes_read and Superblock from write()