### PR TITLE
Flatten the nodes tree into a vec

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -237,15 +237,17 @@ impl<'a> Entry<'a> {
         dir
     }
 
-    /// Create alphabetically sorted entries
+    /// Create entries, input need to be alphabetically sorted
     #[instrument(skip_all)]
-    pub(crate) fn into_dir(mut entries: Vec<Self>) -> Vec<Dir> {
-        entries.sort_unstable_by(|a, b| a.name.cmp(b.name));
-
+    pub(crate) fn into_dir(entries: Vec<Self>) -> Vec<Dir> {
         let mut dirs = vec![];
         let mut creating_dir = vec![];
-        let mut creating_start = entries[0].start;
         let mut iter = entries.iter().peekable();
+        let mut creating_start = if let Some(entry) = iter.peek() {
+            entry.start
+        } else {
+            return vec![];
+        };
 
         while let Some(e) = iter.next() {
             creating_dir.push(e);
@@ -267,7 +269,7 @@ impl<'a> Entry<'a> {
             }
         }
 
-        trace!("DIIIIIIIIIIR: {:#02x?}", dirs);
+        trace!("DIIIIIIIIIIR: {:#02x?}", &dirs);
         dirs
     }
 }
@@ -289,19 +291,19 @@ mod tests {
             },
             Entry {
                 start: 1,
-                offset: 0x200,
-                inode: 6,
-                t: InodeId::BasicDirectory,
-                name_size: 0x01,
-                name: b"zz",
-            },
-            Entry {
-                start: 1,
                 offset: 0x300,
                 inode: 5,
                 t: InodeId::BasicDirectory,
                 name_size: 0x01,
                 name: b"bb",
+            },
+            Entry {
+                start: 1,
+                offset: 0x200,
+                inode: 6,
+                t: InodeId::BasicDirectory,
+                name_size: 0x01,
+                name: b"zz",
             },
         ];
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -2,3 +2,29 @@
 pub mod node;
 pub mod reader;
 pub mod writer;
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::BackhandError;
+
+//normalize the path, always starts with root, solve relative paths and don't
+//allow prefix (windows stuff like "C:/")
+pub fn normalize_squashfs_path(src: &Path) -> Result<PathBuf, BackhandError> {
+    //always starts with root "/"
+    let mut ret = PathBuf::from(Component::RootDir.as_os_str());
+    for component in src.components() {
+        match component {
+            Component::Prefix(..) => return Err(BackhandError::InvalidFilePath),
+            //ignore, root, always added on creation
+            Component::RootDir => {},
+            Component::CurDir => {},
+            Component::ParentDir => {
+                ret.pop();
+            },
+            Component::Normal(c) => {
+                ret.push(c);
+            },
+        }
+    }
+    Ok(ret)
+}

--- a/src/filesystem/node.rs
+++ b/src/filesystem/node.rs
@@ -1,21 +1,13 @@
 use core::fmt;
 use std::cell::RefCell;
-use std::ffi::OsStr;
-use std::io::{Read, Write};
-use std::path::PathBuf;
-use std::rc::Rc;
+use std::io::Read;
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
 
-use deku::bitvec::BitVec;
-use deku::DekuWrite;
-use tracing::trace;
-
-use crate::data::{Added, DataWriter};
-use crate::entry::Entry;
+use super::normalize_squashfs_path;
+use crate::data::Added;
 use crate::inode::{BasicFile, InodeHeader};
-use crate::kind::Kind;
-use crate::metadata::MetadataWriter;
-use crate::reader::WriteSeek;
-use crate::{BackhandError, FilesystemCompressor, FilesystemReaderFile, SuperBlock};
+use crate::{BackhandError, FilesystemReaderFile};
 
 /// File information for Node
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
@@ -52,10 +44,8 @@ impl From<InodeHeader> for NodeHeader {
 #[derive(Clone, Debug)]
 pub struct Node<T> {
     pub fullpath: PathBuf,
-    pub path: Rc<OsStr>,
     pub header: NodeHeader,
     pub inner: InnerNode<T>,
-    pub(crate) inode_id: Option<u32>,
 }
 
 impl<T> PartialEq for Node<T> {
@@ -76,256 +66,22 @@ impl<T> Ord for Node<T> {
 }
 
 impl<T> Node<T> {
-    pub(crate) fn new(
-        fullpath: PathBuf,
-        path: Rc<OsStr>,
-        header: NodeHeader,
-        inner: InnerNode<T>,
-    ) -> Self {
+    pub(crate) fn new(fullpath: PathBuf, header: NodeHeader, inner: InnerNode<T>) -> Self {
         Self {
             fullpath,
-            path,
             header,
             inner,
-            inode_id: None,
         }
     }
 
     pub fn new_root(header: NodeHeader) -> Self {
         let fullpath = PathBuf::from("/");
-        let path = Rc::from(fullpath.as_os_str());
         let inner = InnerNode::Dir(SquashfsDir::default());
         Self {
             fullpath,
-            path,
             header,
             inner,
-            inode_id: None,
         }
-    }
-
-    pub(crate) fn mut_dir(&mut self) -> Option<&mut SquashfsDir<T>> {
-        match &mut self.inner {
-            InnerNode::Dir(node) => Some(node),
-            _ => None,
-        }
-    }
-
-    pub fn dir(&self) -> Option<&SquashfsDir<T>> {
-        match &self.inner {
-            InnerNode::Dir(node) => Some(node),
-            _ => None,
-        }
-    }
-
-    fn have_children(&self) -> bool {
-        self.dir().map_or(false, |nodes| !nodes.children.is_empty())
-    }
-
-    /// iterator for this file and all files inside this one
-    pub fn all_children(&self) -> impl Iterator<Item = &Node<T>> {
-        [self]
-            .into_iter()
-            .chain(self.dir().into_iter().flat_map(|d| d.files()))
-    }
-
-    ///number of nodes in this tree
-    pub(crate) fn inode_number(&self) -> usize {
-        match &self.inner {
-            InnerNode::Dir(node) => {
-                let num_children: usize = node.children.iter().map(Node::inode_number).sum();
-                num_children + 1
-            },
-            _ => 1,
-        }
-    }
-
-    pub(crate) fn calculate_inode(&mut self, inode_counter: &mut u32) {
-        self.inode_id = Some(*inode_counter);
-        *inode_counter += 1;
-
-        self.mut_dir()
-            .into_iter()
-            .flat_map(|nodes| nodes.children.iter_mut())
-            .for_each(|child| child.calculate_inode(inode_counter));
-    }
-}
-
-impl<'a> Node<SquashfsFileWriter<'a>> {
-    pub(crate) fn write_data<W: WriteSeek>(
-        &mut self,
-        compressor: &FilesystemCompressor,
-        block_size: u32,
-        writer: &mut W,
-        data_writer: &mut DataWriter,
-    ) -> Result<(), BackhandError> {
-        match &mut self.inner {
-            InnerNode::File(file) => {
-                let (filesize, added) = match &file {
-                    SquashfsFileWriter::UserDefined(file) => {
-                        data_writer.add_bytes(file.borrow_mut().as_mut(), writer)?
-                    },
-                    SquashfsFileWriter::SquashfsFile(file) => {
-                        // if the source file and the destination files are both
-                        // squashfs files and use the same compressor and block_size
-                        // just copy the data, don't compress->decompress
-                        if file.system.compressor == compressor.id
-                            && file.system.compression_options == compressor.options
-                            && file.system.block_size == block_size
-                        {
-                            data_writer.just_copy_it(file.raw_data_reader(), writer)?
-                        } else {
-                            let mut buf_read = Vec::with_capacity(file.system.block_size as usize);
-                            let mut buf_decompress =
-                                Vec::with_capacity(file.system.block_size as usize);
-                            data_writer.add_bytes(
-                                file.reader(&mut buf_read, &mut buf_decompress),
-                                writer,
-                            )?
-                        }
-                    },
-                    SquashfsFileWriter::Consumed(_, _) => unreachable!(),
-                };
-                *file = SquashfsFileWriter::Consumed(filesize, added);
-            },
-            InnerNode::Dir(dir) => {
-                dir.children.iter_mut().try_for_each(|child| {
-                    child.write_data(compressor, block_size, writer, data_writer)
-                })?;
-            },
-            _ => (),
-        }
-        Ok(())
-    }
-
-    /// Create SquashFS file system from each node of Tree
-    ///
-    /// This works my recursively creating Inodes and Dirs for each node in the tree. This also
-    /// keeps track of parent directories by calling this function on all nodes of a dir to get only
-    /// the nodes, but going into the child dirs in the case that it contains a child dir.
-    pub(crate) fn write_inode_dir(
-        &self,
-        inode_writer: &'_ mut MetadataWriter,
-        dir_writer: &'_ mut MetadataWriter,
-        parent_inode: u32,
-        superblock: SuperBlock,
-        kind: Kind,
-    ) -> Result<(Option<Entry>, u64), BackhandError> {
-        // If no children, just return since it doesn't have anything recursive/new
-        // directories
-        if !self.have_children() {
-            return Ok((None, 0));
-        }
-
-        let dir = self.dir().unwrap();
-
-        // ladies and gentlemen, we have a directory
-        let mut write_entries = vec![];
-
-        // store parent Inode, this is used for child Dirs, as they will need this to reference
-        // back to this
-        let this_inode = self.inode_id.unwrap();
-
-        // tree has children, this is a Dir, get information of every child node
-        for child in dir.children.iter() {
-            let (l_dir_entries, _) =
-                child.write_inode_dir(inode_writer, dir_writer, this_inode, superblock, kind)?;
-            if let Some(entry) = l_dir_entries {
-                write_entries.push(entry);
-            }
-        }
-
-        // write child inodes
-        for node in dir.children.iter().filter(|c| !c.have_children()) {
-            let node_id = node.inode_id.unwrap();
-            let entry = match &node.inner {
-                InnerNode::Dir(_dir) => Entry::path(
-                    &node.path,
-                    node.header,
-                    node_id,
-                    this_inode,
-                    inode_writer,
-                    3, // Empty path
-                    dir_writer.uncompressed_bytes.len() as u16,
-                    dir_writer.metadata_start,
-                    &superblock,
-                    kind,
-                ),
-                InnerNode::File(SquashfsFileWriter::Consumed(filesize, added)) => Entry::file(
-                    &node.path,
-                    node.header,
-                    node_id,
-                    inode_writer,
-                    *filesize,
-                    added,
-                    &superblock,
-                    kind,
-                ),
-                InnerNode::File(_) => unreachable!(),
-                InnerNode::Symlink(symlink) => Entry::symlink(
-                    &node.path,
-                    node.header,
-                    symlink,
-                    node_id,
-                    inode_writer,
-                    &superblock,
-                    kind,
-                ),
-                InnerNode::CharacterDevice(char) => Entry::char(
-                    &node.path,
-                    node.header,
-                    char,
-                    node_id,
-                    inode_writer,
-                    &superblock,
-                    kind,
-                ),
-                InnerNode::BlockDevice(block) => Entry::block_device(
-                    &node.path,
-                    node.header,
-                    block,
-                    node_id,
-                    inode_writer,
-                    &superblock,
-                    kind,
-                ),
-            };
-            write_entries.push(entry);
-        }
-
-        // write dir
-        let block_index = dir_writer.metadata_start;
-        let block_offset = dir_writer.uncompressed_bytes.len() as u16;
-        trace!("WRITING DIR: {block_offset:#02x?}");
-        let mut total_size = 3;
-        for dir in Entry::into_dir(write_entries) {
-            trace!("WRITING DIR: {dir:#02x?}");
-
-            let mut bv = BitVec::new();
-            dir.write(&mut bv, kind)?;
-            let bytes = bv.as_raw_slice();
-            dir_writer.write_all(bv.as_raw_slice())?;
-
-            total_size += bytes.len() as u16;
-        }
-
-        //trace!("BEFORE: {:#02x?}", child);
-        let entry = Entry::path(
-            &self.path,
-            self.header,
-            this_inode,
-            parent_inode,
-            inode_writer,
-            total_size,
-            block_offset,
-            block_index,
-            &superblock,
-            kind,
-        );
-        let root_inode = ((entry.start as u64) << 16) | ((entry.offset as u64) & 0xffff);
-
-        trace!("[{:?}] entries: {:#02x?}", &self.path, &entry);
-        Ok((Some(entry), root_inode))
     }
 }
 
@@ -335,7 +91,7 @@ pub enum InnerNode<T> {
     /// Either [`SquashfsFileReader`] or [`SquashfsFileWriter`]
     File(T),
     Symlink(SquashfsSymlink),
-    Dir(SquashfsDir<T>),
+    Dir(SquashfsDir),
     CharacterDevice(SquashfsCharacterDevice),
     BlockDevice(SquashfsBlockDevice),
 }
@@ -366,62 +122,107 @@ pub struct SquashfsSymlink {
 }
 
 /// Directory for filesystem
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct SquashfsDir<T> {
-    pub children: Vec<Node<T>>,
-}
-impl<T> Default for SquashfsDir<T> {
-    fn default() -> Self {
-        Self {
-            children: Vec::default(),
-        }
-    }
-}
-impl<T> SquashfsDir<T> {
-    fn get_index(&self, filename: &OsStr) -> Option<usize> {
-        self.children
-            .binary_search_by(|node| node.path.as_ref().cmp(filename))
-            .ok()
-    }
-
-    pub fn get(&self, filename: &OsStr) -> Option<&Node<T>> {
-        self.get_index(filename).map(|i| &self.children[i])
-    }
-
-    pub fn get_mut<'a>(&'a mut self, filename: &OsStr) -> Option<&'a mut Node<T>> {
-        self.get_index(filename).map(|i| &mut self.children[i])
-    }
-
-    pub fn insert(&mut self, new: Node<T>) -> Result<&mut Node<T>, BackhandError> {
-        match self.children.binary_search(&new) {
-            //this path is already in this directory
-            Ok(_i) => Err(BackhandError::DuplicatedFileName),
-            //insert at this position
-            Err(i) => {
-                self.children.insert(i, new);
-                Ok(&mut self.children[i])
-            },
-        }
-    }
-
-    /// iterator for all files inside this dir
-    pub fn files(&self) -> impl Iterator<Item = &Node<T>> {
-        self.children.iter().flat_map(|c| {
-            let children = c.all_children();
-            let dyn_children: Box<dyn Iterator<Item = _>> = Box::new(children);
-            dyn_children
-        })
-    }
-}
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub struct SquashfsDir {}
 
 /// Character Device for filesystem
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct SquashfsCharacterDevice {
     pub device_number: u32,
 }
 
 /// Block Device for filesystem
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct SquashfsBlockDevice {
     pub device_number: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct Nodes<T> {
+    pub nodes: Vec<Node<T>>,
+}
+
+impl<T> Nodes<T> {
+    pub fn new_root(header: NodeHeader) -> Self {
+        Self {
+            nodes: vec![Node::new_root(header)],
+        }
+    }
+
+    pub fn root(&self) -> &Node<T> {
+        &self.nodes[0]
+    }
+
+    pub fn root_mut(&mut self) -> &mut Node<T> {
+        &mut self.nodes[0]
+    }
+
+    pub fn node_mut<S: AsRef<Path>>(&mut self, path: S) -> Option<&mut Node<T>> {
+        //the search path root prefix is optional, so remove it if present to
+        //not affect the search
+        let find_path = normalize_squashfs_path(path.as_ref()).ok()?;
+        self.nodes
+            .binary_search_by(|node| node.fullpath.cmp(&find_path))
+            .ok()
+            .map(|found| &mut self.nodes[found])
+    }
+
+    pub fn insert(&mut self, node: Node<T>) -> Result<(), BackhandError> {
+        let path = &node.fullpath;
+        let parent = node
+            .fullpath
+            .parent()
+            .ok_or(BackhandError::InvalidFilePath)?;
+
+        //check the parent exists
+        let _parent = self
+            .node_mut(parent)
+            .ok_or(BackhandError::InvalidFilePath)?;
+
+        match self
+            .nodes
+            .binary_search_by(|node| node.fullpath.as_path().cmp(path))
+        {
+            //file with this fullpath already exists
+            Ok(_index) => Err(BackhandError::DuplicatedFileName),
+            //file don't exists, insert it at this location
+            Err(index) => {
+                self.nodes.insert(index, node);
+                Ok(())
+            },
+        }
+    }
+
+    fn inner_children_of(&self, node_index: usize) -> Option<&[Node<T>]> {
+        let parent = &self.nodes[node_index];
+        let children_start = node_index + 1;
+        let unbounded_children = self.nodes.get(children_start..)?;
+        let children_len = unbounded_children
+            .iter()
+            .enumerate()
+            .find(|(_, node)| !node.fullpath.starts_with(&parent.fullpath))
+            .map(|(index, _)| index)
+            .unwrap_or(unbounded_children.len());
+        Some(&unbounded_children[..children_len])
+    }
+
+    pub fn node(&self, node_index: NonZeroUsize) -> Option<&Node<T>> {
+        self.nodes.get(node_index.get() - 1)
+    }
+
+    pub fn children_of(
+        &self,
+        node_index: NonZeroUsize,
+    ) -> impl Iterator<Item = (NonZeroUsize, &Node<T>)> {
+        self.inner_children_of(node_index.get() - 1)
+            .unwrap_or(&[])
+            .iter()
+            .enumerate()
+            .map(move |(index, node)| {
+                (
+                    NonZeroUsize::new(node_index.get() + index + 1).unwrap(),
+                    node,
+                )
+            })
+    }
 }

--- a/src/filesystem/reader.rs
+++ b/src/filesystem/reader.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::io::{Read, SeekFrom};
 
+use super::node::Nodes;
 use crate::compressor::{self, CompressionOptions, Compressor};
 use crate::data::DataSize;
 use crate::error::BackhandError;
@@ -79,7 +80,7 @@ pub struct FilesystemReader {
     /// Fragments Lookup Table
     pub fragments: Option<Vec<Fragment>>,
     /// All files and directories in filesystem
-    pub root: Node<SquashfsFileReader>,
+    pub root: Nodes<SquashfsFileReader>,
     // File reader
     pub(crate) reader: RefCell<Box<dyn ReadSeek>>,
     // Cache used in the decompression
@@ -159,7 +160,7 @@ impl FilesystemReader {
 
     /// iterator of all files, including the root
     pub fn files(&self) -> impl Iterator<Item = &Node<SquashfsFileReader>> {
-        self.root.all_children()
+        self.root.nodes.iter()
     }
 }
 


### PR DESCRIPTION
This is one more step to lower the memory use for bug squashfs files. This probably don't have a huge effect on itself, but will probably allow future improvements.