### PR TITLE
Testing zune-inflate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "tracing-subscriber",
  "xz2",
  "zstd",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -1171,6 +1172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,4 +1714,13 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440a08fd59c6442e4b846ea9b10386c38307eae728b216e1ab2c305d1c9daaf8"
+dependencies = [
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.2.0", features = ["derive"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
 byte-unit = "4.0.18"
 libc = "0.2.140"
+zune-inflate = "0.2.53"
 
 [features]
 default = ["xz", "gzip", "lzo", "zstd"]

--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -1,6 +1,6 @@
 //! Types of supported compression algorithms
 
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Write};
 
 use deku::prelude::*;
 #[cfg(feature = "gzip")]
@@ -118,8 +118,13 @@ pub(crate) fn decompress(
     match compressor {
         #[cfg(feature = "gzip")]
         Compressor::Gzip => {
-            let mut decoder = flate2::read::ZlibDecoder::new(bytes);
-            decoder.read_to_end(out)?;
+            //let mut decoder = flate2::read::ZlibDecoder::new(bytes);
+            //decoder.read_to_end(out)?;
+
+            let mut decoder = zune_inflate::DeflateDecoder::new(bytes);
+            // panic on errors, because that's the cool way to go
+            let decompressed_data = decoder.decode_zlib().unwrap();
+            out.write_all(&decompressed_data)?;
         },
         #[cfg(feature = "xz")]
         Compressor::Xz => {


### PR DESCRIPTION
Looking fast 

```
 Summary
  './unsquashfs-zune -f -d /tmp/tmp.xdzf22MkJz test-assets/test_00/bytes.squashfs' ran
    1.36 ± 0.13 times faster than './target/release/unsquashfs -f -d /tmp/tmp.d7M4JwWOuh test-assets/test_00/bytes.squashfs'
    1.47 ± 0.18 times faster than 'unsquashfs -d /tmp/tmp.P3Z0M8qQBB -p 1 -f -ignore-errors -no-exit-code test-assets/test_00/bytes.squashfs'
```