### PR TITLE
unsquashfs: Add --path-filter to limit extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -565,6 +566,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,7 +718,7 @@ checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.9",
  "windows-sys 0.45.0",
 ]
 
@@ -772,6 +784,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "log"
@@ -1086,10 +1104,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.7",
  "windows-sys 0.45.0",
 ]
 
@@ -1252,7 +1284,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.36.9",
  "windows-sys 0.42.0",
 ]
 
@@ -1263,6 +1295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1588,13 +1630,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1603,7 +1645,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1612,13 +1663,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1628,10 +1694,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1640,10 +1718,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1652,16 +1742,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustc-hash = "1.1.0"
 
 # for bins
 nix = { version = "0.26.2", default-features = false, features = ["fs"] }
-clap = { version = "4.2.0", features = ["derive"] }
+clap = { version = "4.2.0", features = ["derive", "wrap_help"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
 byte-unit = "4.0.18"
 libc = "0.2.140"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ These are currently under development and are missing features, MR's welcome!
 To install, run `cargo install backhand --locked`, or download from the
 [latest github release](https://github.com/wcampbell0x2a/backhand/releases/latest).
 
+See ``--help`` for more information.
+
 ### unsquashfs-backhand
 ```no_test
 tool to uncompress, extract and list squashfs filesystems
@@ -74,11 +76,13 @@ Options:
   -l, --list                       List filesystem, do not write to DEST
   -d, --dest <PATHNAME>            Extract to [PATHNAME] [default: squashfs-root]
   -i, --info                       Print files as they are extracted
+      --path-filter <PATH_FILTER>  Limit filesystem extraction [default: /]
   -f, --force                      If file already exists then overwrite
   -s, --stat                       Display filesystem superblock information
-  -k, --kind <KIND>                Kind(type of image) to parse [default: le_v4_0] [possible values: be_v4_0, le_v4_0, avm_be_v4_0]
+  -k, --kind <KIND>                Kind(type of image) to parse [default: le_v4_0] [possible values: be_v4_0, le_v4_0,
+                                   avm_be_v4_0]
       --completions <COMPLETIONS>  Emit shell completion scripts [possible values: bash, elvish, fish, powershell, zsh]
-  -h, --help                       Print help
+  -h, --help                       Print help (see more with '--help')
   -V, --version                    Print version
 ```
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -7,8 +7,8 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::BackhandError;
 
-//normalize the path, always starts with root, solve relative paths and don't
-//allow prefix (windows stuff like "C:/")
+// normalize the path, always starts with root, solve relative paths and don't
+// allow prefix (windows stuff like "C:/")
 pub fn normalize_squashfs_path(src: &Path) -> Result<PathBuf, BackhandError> {
     //always starts with root "/"
     let mut ret = PathBuf::from(Component::RootDir.as_os_str());

--- a/tests/replace.rs
+++ b/tests/replace.rs
@@ -1,0 +1,96 @@
+mod bin;
+mod common;
+
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use tempfile::tempdir;
+use test_assets::TestAssetDef;
+use test_log::test;
+
+#[test]
+#[cfg(feature = "xz")]
+fn test_replace() {
+    const FILE_NAME: &str = "out.squashfs";
+    let asset_defs = [TestAssetDef {
+        filename: FILE_NAME.to_string(),
+        hash: "6195e4d8d14c63dffa9691d36efa1eda2ee975b476bb95d4a0b59638fd9973cb".to_string(),
+        url: format!("wcampbell.dev/squashfs/testing/test_05/{FILE_NAME}"),
+    }];
+    const TEST_PATH: &str = "test-assets/test_05";
+
+    test_assets::download_test_files(&asset_defs, TEST_PATH, true).unwrap();
+    let image_path = format!("{TEST_PATH}/{FILE_NAME}");
+
+    // extract single file
+    let tmp_dir = tempdir().unwrap();
+    let cmd = Command::cargo_bin("unsquashfs")
+        .unwrap()
+        .env("RUST_LOG", "none")
+        .args([
+            "--path-filter",
+            r#"/b/c/d"#,
+            "-i",
+            &image_path,
+            "-d",
+            tmp_dir.path().join("squashfs-root-rust").to_str().unwrap(),
+        ])
+        .unwrap();
+    cmd.assert().code(0);
+
+    // edit that file
+    let text = b"The mystery of life isn't a problem to solve, but a reality to experience.";
+    std::fs::write(
+        tmp_dir
+            .path()
+            .join("squashfs-root-rust/b/c/d")
+            .to_str()
+            .unwrap(),
+        text,
+    )
+    .unwrap();
+
+    // replace that file
+    let cmd = Command::cargo_bin("replace")
+        .unwrap()
+        .env("RUST_LOG", "none")
+        .args([
+            &image_path,
+            tmp_dir
+                .path()
+                .join("squashfs-root-rust/b/c/d")
+                .to_str()
+                .unwrap(),
+            "/b/c/d",
+            "-o",
+            tmp_dir.path().join("replaced").to_str().unwrap(),
+        ])
+        .unwrap();
+    cmd.assert().code(0);
+
+    // extract
+    let cmd = Command::cargo_bin("unsquashfs")
+        .unwrap()
+        .env("RUST_LOG", "none")
+        .args([
+            "--path-filter",
+            r#"/b/c/d"#,
+            "-i",
+            tmp_dir.path().join("replaced").to_str().unwrap(),
+            "-d",
+            tmp_dir.path().join("squashfs-root-rust2").to_str().unwrap(),
+        ])
+        .unwrap();
+    cmd.assert().code(0);
+
+    // assert the text changed!
+    let bytes = std::fs::read(
+        tmp_dir
+            .path()
+            .join("squashfs-root-rust2/b/c/d")
+            .to_str()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(bytes, text);
+}

--- a/tests/unsquashfs.rs
+++ b/tests/unsquashfs.rs
@@ -1,0 +1,52 @@
+mod bin;
+mod common;
+
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use test_assets::TestAssetDef;
+
+#[test]
+#[cfg(feature = "xz")]
+fn test_unsquashfs_cli() {
+    const FILE_NAME: &str = "870D97.squashfs";
+    let asset_defs = [TestAssetDef {
+        filename: FILE_NAME.to_string(),
+        hash: "a73325883568ba47eaa5379c7768ded5661d61841a81d6c987371842960ac6a2".to_string(),
+        url: format!("wcampbell.dev/squashfs/testing/test_re815xev1/{FILE_NAME}"),
+    }];
+    const TEST_PATH: &str = "test-assets/test_re815_xev160";
+
+    test_assets::download_test_files(&asset_defs, TEST_PATH, true).unwrap();
+    let image_path = format!("{TEST_PATH}/{FILE_NAME}");
+
+    // single file
+    let cmd = Command::cargo_bin("unsquashfs")
+        .unwrap()
+        .env("RUST_LOG", "none")
+        .args(["--path-filter", r#"/usr/bin/wget"#, "-l", &image_path])
+        .unwrap();
+    cmd.assert().stdout(
+        r#"/
+/usr
+/usr/bin
+/usr/bin/wget
+"#,
+    );
+
+    // multiple file
+    let cmd = Command::cargo_bin("unsquashfs")
+        .unwrap()
+        .env("RUST_LOG", "none")
+        .args(["--path-filter", r#"/www/webpages/data"#, "-l", &image_path])
+        .unwrap();
+    cmd.assert().stdout(
+        r#"/
+/www
+/www/webpages
+/www/webpages/data
+/www/webpages/data/region.json
+/www/webpages/data/timezone.json
+"#,
+    );
+}


### PR DESCRIPTION
- Add --path-filter. For instance, when given "/usr/bin/", it will parse whatever files exist in "/usr/bin" such like "/usr/bin/*". It will also correctly put that file with the correct file permissions and modes for /, /usr/, and /usr/bin. If given an exact file, only return that file (with correct parent nodes)

See #234