### PR TITLE
ci: Use new dist profile for release binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -32,12 +32,12 @@ jobs:
           target: ${{ matrix.targets }}
       - run: cargo install cargo-quickinstall
       - run: cargo quickinstall cross@0.2.5 --force
-      - run: cross build --bins --locked --release --target ${{ matrix.targets }}
+      - run: cross build --bins --locked --target ${{ matrix.targets }} --profile=dist
 
       - name: archive
         run: |
           tar -czvf backhand-${{ matrix.targets }}.tar.gz \
-              -C target/${{ matrix.targets }}/release/ $BINS
+              -C target/${{ matrix.targets }}/dist/ $BINS
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -55,6 +55,6 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: backhand-${{ matrix.targets }}.tar.gz
-          asset_name: backhand-${{ matrix.targets }}.tar.gz
+          asset_name: backhand-${{ github.ref_name }}-${{ matrix.targets }}.tar.gz
           tag: ${{ github.ref }}
           overwrite: true

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -44,8 +44,11 @@ jobs:
           name: backhand-${{ matrix.targets }}.tar.gz
           path: backhand-${{ matrix.targets }}.tar.gz
 
-        # check semvar before release!
+      # check semvar before release!
       - name: Check semver
+        env:
+          # disable static build for this job
+          RUSTFLAGS: ""
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: obi1kenobi/cargo-semver-checks-action@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # Unreleased
+## All binaries
+### Changes
+- `strip` and `LTO` are enabled for release binaries
+
 ## ci
 - Fix libc calls, add testing and release binaries for the following platforms:([#259](https://github.com/wcampbell0x2a/backhand/pull/259))
    - `aarch64-unknown-linux-musl`
@@ -68,7 +72,7 @@ Added items to the public API
 </details>
 
 ## All binaries
-## Changes
+### Changes
 - jemalloc is now used for `-musl` release targets for performance reasons ([#254](https://github.com/wcampbell0x2a/backhand/pull/254))
 - `HAVE_DECODER_ARM`, `HAVE_DECODER_ARM64`, and `HAVE_DECODER_ARMTHUMB` filter flags are now defined for xz2. This only effects static build created in our CI. ([#254](https://github.com/wcampbell0x2a/backhand/pull/248))
 - Add `RUST_LOG` and available Decompressors to `--help` of all binaries ([#242](https://github.com/wcampbell0x2a/backhand/pull/242))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,10 @@ harness = false
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
 version = "0.5.0"
+
+# Release(dist) binaries are setup for maximum runtime speed, at the cost of CI time
+[profile.dist]
+inherits = "release"
+codegen-units = 1
+lto = true
+strip = true


### PR DESCRIPTION
* Add LTO: This doesn't increase performance by a measurable amount. The compression algorithms need looked into to enable in their build system.
* Add stripped binaries for dist releases from ci