### PR TITLE
backhand: Add FilesystemWriter::uncompressed_size()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fix
 - When creating an empty image using `FilesystemWriter::default()`, correctly create the ID table for UID and GID entries. Reported: ([@hwittenborn](https://github.com/hwittenborn)) ([!250](https://github.com/wcampbell0x2a/backhand/issues/275)), Fixed: ([#275](https://github.com/wcampbell0x2a/backhand/pull/275))
 
+### Changes
+- Add `FilesystemWriter::uncompressed_size()`, which gives the total size of all files once
+  uncompressed. This reads the size of both files from the image, and
+  the size of the files not written to an image at the time of writer. ([#274](https://github.com/wcampbell0x2a/backhand/pull/274))
+- Change `SquashfsFileWriter::UserDefined` to take a `BufReadSeek`, so that the file size can be
+  found when needed. ([#274](https://github.com/wcampbell0x2a/backhand/pull/274))
+
 ## All binaries
 ### Changes
 - `strip` and `LTO` are enabled for release binaries

--- a/src/bin/add.rs
+++ b/src/bin/add.rs
@@ -75,7 +75,7 @@ fn main() -> ExitCode {
 
     // create new file
     if let Some(file) = args.file {
-        let new_file = File::open(&file).unwrap();
+        let new_file = BufReader::new(File::open(&file).unwrap());
 
         // if metadata isn't already defined, use from file
         let meta = file.metadata().unwrap();

--- a/src/bin/replace.rs
+++ b/src/bin/replace.rs
@@ -49,7 +49,7 @@ fn main() -> ExitCode {
     let mut filesystem = FilesystemWriter::from_fs_reader(&filesystem).unwrap();
 
     // Modify file
-    let new_file = File::open(&args.file).unwrap();
+    let new_file = BufReader::new(File::open(&args.file).unwrap());
     if let Err(e) = filesystem.replace_file(args.file_path, new_file) {
         println!("[!] {e}");
         return ExitCode::FAILURE;

--- a/src/filesystem/node.rs
+++ b/src/filesystem/node.rs
@@ -1,13 +1,12 @@
 use core::fmt;
 use std::cell::RefCell;
-use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 use super::normalize_squashfs_path;
 use crate::data::Added;
 use crate::inode::{BasicFile, InodeHeader};
-use crate::{BackhandError, FilesystemReaderFile, Id};
+use crate::{BackhandError, BufReadSeek, FilesystemReaderFile, Id};
 
 /// File information for Node
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
@@ -106,7 +105,7 @@ pub struct SquashfsFileReader {
 
 /// Read file from other SquashfsFile or an user file
 pub enum SquashfsFileWriter<'a> {
-    UserDefined(RefCell<Box<dyn Read + 'a>>),
+    UserDefined(RefCell<Box<dyn BufReadSeek + 'a>>),
     SquashfsFile(FilesystemReaderFile<'a>),
     Consumed(usize, Added),
 }

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -72,6 +72,7 @@ fn test_raw_00() {
 
     // create the modified squashfs
     let mut output = std::io::BufWriter::new(std::fs::File::create(&new_path).unwrap());
+    assert_eq!(2 + 0xff, fs.uncompressed_size().unwrap());
     let (superblock, bytes_written) = fs.write(&mut output).unwrap();
 
     // 8KiB


### PR DESCRIPTION
* Add uncompressed_size(), which gives the total size of all files once uncompressed. This reads the size of both files from the image, and the size of the files not written to an image at the time of writer.
* Change SquashfsFileWriter::UserDefined to take a BufReadSeek, so that the file size can be found when needed