### PR TITLE
backhand: Fix FilesystemWriter::default() empty generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # Unreleased
+## backhand
+### Bug Fix
+- When creating an empty image using `FilesystemWriter::default()`, correctly create the ID table for UID and GID entries. Reported: ([@hwittenborn](https://github.com/hwittenborn)) ([!250](https://github.com/wcampbell0x2a/backhand/issues/275)), Fixed: ([#275](https://github.com/wcampbell0x2a/backhand/pull/275))
+
 ## All binaries
 ### Changes
 - `strip` and `LTO` are enabled for release binaries

--- a/src/filesystem/writer.rs
+++ b/src/filesystem/writer.rs
@@ -91,7 +91,7 @@ impl<'a> Default for FilesystemWriter<'a> {
         Self {
             block_size,
             mod_time: 0,
-            id_table: vec![],
+            id_table: Id::root(),
             fs_compressor: FilesystemCompressor::default(),
             kind: Kind {
                 inner: Rc::new(LE_V4_0),

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,0 +1,8 @@
+/// https://github.com/wcampbell0x2a/backhand/issues/275
+#[test]
+#[cfg(feature = "xz")]
+fn issue_275() {
+    let mut writer = std::io::Cursor::new(vec![]);
+    let mut fs = backhand::FilesystemWriter::default();
+    fs.write(&mut writer).unwrap();
+}


### PR DESCRIPTION
* Use Id::root() when creating an empty FilesystemWriter, so that the 0 index that is also added from a node will be unwrapped correctly later