### PR TITLE
backhand: Fix clippy::incorrect_clone_impl_on_copy_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## backhand
 ### Bug Fix
 - When creating an empty image using `FilesystemWriter::default()`, correctly create the ID table for UID and GID entries. Reported: ([@hwittenborn](https://github.com/hwittenborn)) ([!250](https://github.com/wcampbell0x2a/backhand/issues/275)), Fixed: ([#275](https://github.com/wcampbell0x2a/backhand/pull/275))
+- Remove manual `Clone` impl for `FilesystemReaderFile` ([#277](https://github.com/wcampbell0x2a/backhand/pull/277))
 
 ## All binaries
 ### Changes

--- a/src/filesystem/reader.rs
+++ b/src/filesystem/reader.rs
@@ -169,19 +169,10 @@ impl FilesystemReader {
 }
 
 /// Filesystem handle for file
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct FilesystemReaderFile<'a> {
     pub(crate) system: &'a FilesystemReader,
     pub(crate) basic: &'a BasicFile,
-}
-
-impl<'a> Clone for FilesystemReaderFile<'a> {
-    fn clone(&self) -> Self {
-        Self {
-            system: self.system,
-            basic: self.basic,
-        }
-    }
 }
 
 impl<'a> FilesystemReaderFile<'a> {


### PR DESCRIPTION
* Remove manual Clone impl for FilesystemReaderFile.
* See: https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_clone_impl_on_copy_type
  >  If both Clone and Copy are implemented, they must agree.
  > This is done by dereferencing self in Clone’s implementation.
  > Anything else is incorrect.