### PR TITLE
ci: Use --release for coverage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@e8c64729e2a2a2c3cfa6751fa496b34ca19f390c # cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --workspace --codecov --output-path codecov.json --features __test_unsquashfs
+        run: cargo llvm-cov --workspace --codecov --output-path codecov.json --features __test_unsquashfs --release
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:


### PR DESCRIPTION
- This runs the binaries, so this speeds up the CI by a large amount