### PR TITLE
lax FilesystemWriter lifetimes

### DIFF
--- a/backhand-cli/src/bin/add.rs
+++ b/backhand-cli/src/bin/add.rs
@@ -103,8 +103,8 @@ fn main() -> ExitCode {
     }
 
     // write new file
-    let mut output = File::create(&args.out).unwrap();
-    if let Err(e) = filesystem.write(&mut output) {
+    let output = File::create(&args.out).unwrap();
+    if let Err(e) = filesystem.write(output) {
         println!("[!] {e}");
     }
     println!("[-] added file and wrote to {}", args.out.display());

--- a/backhand-cli/src/bin/replace.rs
+++ b/backhand-cli/src/bin/replace.rs
@@ -54,8 +54,8 @@ fn main() -> ExitCode {
     }
 
     // write new file
-    let mut output = File::create(&args.out).unwrap();
-    filesystem.write(&mut output).unwrap();
+    let output = File::create(&args.out).unwrap();
+    filesystem.write(output).unwrap();
     println!("replaced file and wrote to {}", args.out.display());
 
     ExitCode::SUCCESS

--- a/backhand/src/data.rs
+++ b/backhand/src/data.rs
@@ -118,7 +118,7 @@ impl<'a> DataWriter<'a> {
     pub(crate) fn just_copy_it<W: WriteSeek>(
         &mut self,
         mut reader: SquashfsRawData,
-        writer: &mut W,
+        mut writer: W,
     ) -> Result<(usize, Added), BackhandError> {
         //just clone it, because block sizes where never modified, just copy it
         let mut block_sizes = reader.file.basic.block_sizes.clone();
@@ -181,7 +181,7 @@ impl<'a> DataWriter<'a> {
     pub(crate) fn add_bytes<W: WriteSeek>(
         &mut self,
         reader: impl Read,
-        writer: &mut W,
+        mut writer: W,
     ) -> Result<(usize, Added), BackhandError> {
         let mut chunk_reader = DataWriterChunkReader {
             chunk: vec![0u8; self.block_size as usize],
@@ -230,7 +230,7 @@ impl<'a> DataWriter<'a> {
 
     /// Compress the fragments that were under length, write to data, add to fragment table, clear
     /// current fragment_bytes
-    pub fn finalize<W: Write + Seek>(&mut self, writer: &mut W) -> Result<(), BackhandError> {
+    pub fn finalize<W: Write + Seek>(&mut self, mut writer: W) -> Result<(), BackhandError> {
         let start = writer.stream_position()?;
         let cb = self.kind.compress(&self.fragment_bytes, self.fs_compressor, self.block_size)?;
 

--- a/backhand/src/filesystem/node.rs
+++ b/backhand/src/filesystem/node.rs
@@ -92,13 +92,13 @@ pub struct SquashfsFileReader {
 }
 
 /// Read file from other SquashfsFile or an user file
-pub enum SquashfsFileWriter<'a, 'b> {
-    UserDefined(Arc<Mutex<dyn Read + 'b>>),
+pub enum SquashfsFileWriter<'a, 'b, 'c> {
+    UserDefined(Arc<Mutex<dyn Read + 'c>>),
     SquashfsFile(FilesystemReaderFile<'a, 'b>),
     Consumed(usize, Added),
 }
 
-impl<'a, 'b> fmt::Debug for SquashfsFileWriter<'a, 'b> {
+impl fmt::Debug for SquashfsFileWriter<'_, '_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FileWriter").finish()
     }

--- a/backhand/src/metadata.rs
+++ b/backhand/src/metadata.rs
@@ -74,7 +74,7 @@ impl MetadataWriter {
         Ok(())
     }
 
-    pub fn finalize<W: Write + Seek>(&mut self, out: &mut W) -> Result<(), BackhandError> {
+    pub fn finalize<W: Write + Seek>(&mut self, mut out: W) -> Result<(), BackhandError> {
         //add any remaining data
         while !self.uncompressed_bytes.is_empty() {
             self.add_block()?;


### PR DESCRIPTION
This commit allows two things:
- Calling `FilesystemWriter::write` with Owned and RefMut writer.
- push dir/file/etc with lifetimes unrelated to reader from `from_fs_reader`

Note: add.rs and replace.rs didn't required any change. I did it to show users that the writer parameter could be consumed by the function.