### PR TITLE
add fuzzer target

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -13,6 +13,9 @@ name = "arbitrary"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "autocfg"
@@ -144,6 +147,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -467,11 +481,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 
 [dependencies.backhand]
 path = "../backhand"
@@ -37,6 +37,13 @@ name = "raw"
 path = "fuzz_targets/raw.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "write_read_write"
+path = "fuzz_targets/write_read_write.rs"
+test = false
+doc = false
+
 
 [features]
 xz-static = ["backhand/xz-static"]

--- a/fuzz/fuzz_targets/write_read_write.rs
+++ b/fuzz/fuzz_targets/write_read_write.rs
@@ -1,0 +1,159 @@
+#![no_main]
+
+use std::io::Cursor;
+use std::path::Path;
+
+use backhand::{FilesystemReader, FilesystemWriter, NodeHeader};
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Result, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Debug, Default)]
+struct Header(NodeHeader);
+
+impl Arbitrary<'_> for Header {
+    fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
+        Ok(Self(NodeHeader {
+            permissions: u.arbitrary()?,
+            uid: u.arbitrary()?,
+            gid: u.arbitrary()?,
+            mtime: u.arbitrary()?,
+        }))
+    }
+
+    #[inline]
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (14, Some(14))
+    }
+}
+
+fn consume_path<'a>(u: &mut Unstructured<'a>, size: usize) -> &'a Path {
+    // limit Paths to 255
+    let bytes = u.bytes(size.min(255)).unwrap();
+    use std::os::unix::ffi::*;
+    let os_str = std::ffi::OsStr::from_bytes(bytes);
+    Path::new(os_str)
+}
+
+// NOTE don't use the PathBuf implementation of Arbitary, because it rely on the
+// &str implementation. This is a problem because it don't have a size limit
+// and we want to also have paths made of non-utf8 bytes
+#[derive(Debug)]
+struct MyPath<'a>(&'a Path);
+impl<'a> Arbitrary<'a> for MyPath<'a> {
+    #[cfg(unix)]
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let size = u.arbitrary_len::<u8>()?;
+        Ok(MyPath(consume_path(u, size)))
+    }
+
+    fn arbitrary_take_rest(mut u: Unstructured<'a>) -> Result<Self> {
+        let size = u.len();
+        Ok(MyPath(consume_path(&mut u, size)))
+    }
+
+    #[inline]
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+
+#[derive(Debug)]
+struct MyData<'a>(&'a [u8]);
+impl<'a> Arbitrary<'a> for MyData<'a> {
+    #[cfg(unix)]
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        // limit the file size to 10, for speed...
+        let size = u.arbitrary_len::<u8>()?.min(10);
+        Ok(MyData(u.bytes(size)?))
+    }
+
+    fn arbitrary_take_rest(mut u: Unstructured<'a>) -> Result<Self> {
+        let size = u.len();
+        Ok(MyData(u.bytes(size)?))
+    }
+
+    #[inline]
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum Node<'a> {
+    File { path: MyPath<'a>, header: Header, data: MyData<'a> },
+    Dir { path: MyPath<'a>, header: Header },
+    Symlink { src: MyPath<'a>, header: Header, dst: MyPath<'a> },
+    CharDev { file: MyPath<'a>, header: Header, device_num: u32 },
+    BlockDev { file: MyPath<'a>, header: Header, device_num: u32 },
+}
+
+impl<'a> Node<'a> {
+    fn path(&self) -> &'a Path {
+        match self {
+            Node::File { path, .. }
+            | Node::Dir { path, .. }
+            | Node::Symlink { src: path, .. }
+            | Node::CharDev { file: path, .. }
+            | Node::BlockDev { file: path, .. } => path.0,
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct Squashfs<'a> {
+    time: u32,
+    nodes: Vec<Node<'a>>,
+}
+
+impl<'a> Squashfs<'a> {
+    fn into_writer(&'a self) -> FilesystemWriter<'static, 'static, 'a> {
+        let mut fs = FilesystemWriter::default();
+        // NOTE no compression to make it fast
+        fs.set_compressor(
+            backhand::FilesystemCompressor::new(backhand::compression::Compressor::None, None)
+                .unwrap(),
+        );
+        fs.set_time(self.time);
+
+        for node in self.nodes.iter() {
+            if let Some(parent) = node.path().parent() {
+                let _ = fs.push_dir_all(parent, NodeHeader::default());
+            }
+            // ignore errors from push_* functions
+            let _ = match &node {
+                Node::File { path, header, data } => {
+                    fs.push_file(Cursor::new(data.0), path.0, header.0)
+                }
+                Node::Dir { path, header } => fs.push_dir(path.0, header.0),
+                Node::Symlink { src, header, dst } => fs.push_symlink(dst.0, src.0, header.0),
+                Node::CharDev { file, header, device_num } => {
+                    fs.push_char_device(*device_num, file.0, header.0)
+                }
+                Node::BlockDev { file, header, device_num } => {
+                    fs.push_block_device(*device_num, file.0, header.0)
+                }
+            };
+        }
+        fs
+    }
+}
+
+fuzz_target!(|input: Squashfs| {
+    // step 1: generate a squashfs file from the random input
+    let mut file_1 = Vec::new();
+    let _ = input.into_writer().write(Cursor::new(&mut file_1)).unwrap();
+
+    // step 2: parse the generated file
+    // all files create using FilesystemWriter should be valid
+    let fs_reader = FilesystemReader::from_reader(Cursor::new(&file_1)).unwrap();
+
+    // step 3: use the parsed file to generate other file
+    let mut squashfs_2 = FilesystemWriter::from_fs_reader(&fs_reader).unwrap();
+    let mut file_2 = Vec::new();
+    let _ = squashfs_2.write(Cursor::new(&mut file_2)).unwrap();
+
+    // step 4: verify parsed data
+    // both generated files need to be equal
+    assert_eq!(file_1, file_2);
+});


### PR DESCRIPTION
This is the target that I used to find #359 and #363.

Maybe there is something wrong with my setup, but the fuzzer is only able to get a few hundred executions per second.

This implementation is also limited by the fact that some Paths that are bigger then 255 bytes result in panic and not error. So we are limited to fuzzing paths that are 255 bytes or shorter.

I suppose having the Deku assertions being transformed from panics into errors could improve fuzzing in the future, let me know what you think.