### PR TITLE
ci: Use PAT token for changelog-auto-commit

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
 
       - uses: dangoslen/dependabot-changelog-helper@15b927ce4f654cd41fb14e5a676d17414b9dbb64 # v3.7.0
         with:


### PR DESCRIPTION
Add hopeful fix for triggering CI on auto-commit push. See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs