### PR TITLE
Remove mips from ci and release builds

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -22,8 +22,6 @@ jobs:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
           - arm-unknown-linux-musleabi
-          - mips-unknown-linux-musl
-          - mipsel-unknown-linux-musl
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add testing and release binaries for the following platforms:([#259](https://github.com/wcampbell0x2a/backhand/pull/259))
    - `aarch64-unknown-linux-musl`
    - `arm-unknown-linux-musleabi`
-   - `mips-unknown-linux-musl`
-   - `mipsel-unknown-linux-musl`
    - `x86_64-unknown-linux-musl` (previously already release supported)
 - Testing and release binaries were not added for macOS, support was tested on that platform.
 ### testing


### PR DESCRIPTION
Remove, as mips has joined the crypt as tier 3 only: https://github.com/rust-lang/rust/pull/115238/ as of https://github.com/rust-lang/rust/releases/tag/1.75.0