### PR TITLE
Fix spurious CI: Add RUST_LOG to cross tests

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,7 @@
 [target.x86_64-unknown-linux-musl]
 pre-build = ["apt-get update && apt-get install --assume-yes squashfs-tools"]
+
+[build.env]
+passthrough = [
+    "RUST_LOG",
+]

--- a/backhand-test/tests/non_standard.rs
+++ b/backhand-test/tests/non_standard.rs
@@ -108,7 +108,7 @@ fn test_custom_compressor() {
     #[derive(Copy, Clone)]
     pub struct CustomCompressor;
 
-    // Special decompress that only has support for the Rust version of gzip: zune-inflate for
+    // Special decompress that only has support for the Rust version of gzip: lideflator for
     // decompression
     impl CompressionAction for CustomCompressor {
         fn decompress(
@@ -142,6 +142,6 @@ fn test_custom_compressor() {
 
     let kind = Kind::new_with_const(&CustomCompressor, kind::BE_V4_0);
 
-    const TEST_PATH: &str = "test-assets/non_standard_be_v4_1";
+    const TEST_PATH: &str = "test-assets/custom_compressor";
     full_test(&asset_defs, FILE_NAME, TEST_PATH, 0, &kind);
 }


### PR DESCRIPTION
Fix bug in TEST_PATH that was causing a racey test with another test *also* writing to the same result file.