### PR TITLE
backhand: Pre-allocate decompress block buffer to block_size

### DIFF
--- a/backhand/src/metadata.rs
+++ b/backhand/src/metadata.rs
@@ -133,7 +133,7 @@ pub fn read_block<R: Read + ?Sized>(
 
     let bytes = if is_compressed(metadata_len) {
         tracing::trace!("compressed");
-        let mut out = Vec::with_capacity(8 * 1024);
+        let mut out = Vec::with_capacity(superblock.block_size as usize);
         kind.inner.compressor.decompress(&buf, &mut out, superblock.compressor)?;
         out
     } else {


### PR DESCRIPTION
This should reduce memory usage for block sizes less then 8KiB