### PR TITLE
Add named pipe (fifo) handling

### DIFF
--- a/backhand/src/filesystem/node.rs
+++ b/backhand/src/filesystem/node.rs
@@ -83,6 +83,7 @@ pub enum InnerNode<T> {
     Dir(SquashfsDir),
     CharacterDevice(SquashfsCharacterDevice),
     BlockDevice(SquashfsBlockDevice),
+    NamedPipe,
 }
 
 /// Unread file for filesystem

--- a/backhand/src/filesystem/reader.rs
+++ b/backhand/src/filesystem/reader.rs
@@ -40,6 +40,7 @@ use crate::{Node, Squashfs, SquashfsFileReader};
 ///         InnerNode::Dir(_) => (),
 ///         InnerNode::CharacterDevice(_) => (),
 ///         InnerNode::BlockDevice(_) => (),
+///         InnerNode::NamedPipe => (),
 ///     }
 /// }
 /// ```

--- a/backhand/src/filesystem/writer.rs
+++ b/backhand/src/filesystem/writer.rs
@@ -210,6 +210,7 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
                     InnerNode::Dir(x) => InnerNode::Dir(*x),
                     InnerNode::CharacterDevice(x) => InnerNode::CharacterDevice(*x),
                     InnerNode::BlockDevice(x) => InnerNode::BlockDevice(*x),
+                    InnerNode::NamedPipe => InnerNode::NamedPipe,
                 };
                 Node { fullpath: node.fullpath.clone(), header: node.header, inner }
             })
@@ -524,6 +525,17 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
                     filename,
                     node.header,
                     block,
+                    node_id.get().try_into().unwrap(),
+                    inode_writer,
+                    superblock,
+                    kind,
+                    id_table,
+                ))
+            }
+            InnerNode::NamedPipe => {
+                return Ok(Entry::named_pipe(
+                    filename,
+                    node.header,
                     node_id.get().try_into().unwrap(),
                     inode_writer,
                     superblock,

--- a/backhand/src/inode.rs
+++ b/backhand/src/inode.rs
@@ -72,6 +72,7 @@ pub enum InodeId {
     BasicSymlink         = 3,
     BasicBlockDevice     = 4,
     BasicCharacterDevice = 5,
+    BasicNamedPipe       = 6, // aka FIFO
     ExtendedDirectory    = 8,
     ExtendedFile         = 9,
     // TODO:
@@ -113,6 +114,9 @@ pub enum InodeInner {
 
     #[deku(id = "InodeId::BasicCharacterDevice")]
     BasicCharacterDevice(BasicDeviceSpecialFile),
+
+    #[deku(id = "InodeId::BasicNamedPipe")]
+    BasicNamedPipe(BasicNamedPipe),
 
     #[deku(id = "InodeId::ExtendedDirectory")]
     ExtendedDirectory(ExtendedDirectory),
@@ -243,4 +247,10 @@ impl BasicSymlink {
 pub struct BasicDeviceSpecialFile {
     pub link_count: u32,
     pub device_number: u32,
+}
+
+#[derive(Debug, DekuRead, DekuWrite, Clone, PartialEq, Eq)]
+#[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
+pub struct BasicNamedPipe {
+    pub link_count: u32,
 }

--- a/backhand/src/squashfs.rs
+++ b/backhand/src/squashfs.rs
@@ -554,6 +554,9 @@ impl<'b> Squashfs<'b> {
                             let device_number = self.block_device(found_inode)?;
                             InnerNode::BlockDevice(SquashfsBlockDevice { device_number })
                         }
+                        InodeId::BasicNamedPipe => {
+                            InnerNode::NamedPipe
+                        }
                         InodeId::ExtendedFile => {
                             return Err(BackhandError::UnsupportedInode(found_inode.inner.clone()))
                         }


### PR DESCRIPTION
I stumbled across a file with named pipe nodes which made `unsquashfs-backhand` panic.

This is my attempt at adding support for named pipes. It is currently missing tests. But I could already extract a private squashfs image containing named pipes.

The redistributable public test file I found contains socket nodes (at least according to the error message I got), so using it as a testcase would require to also implement at least the socket nodes.

A relevant test file from unblob project:
https://github.com/onekey-sec/unblob/blob/0dc4bb53b30b1723245604947669e6817c82de97/tests/integration/filesystem/squashfs/squashfs_v4_le/__input__/squashfs_v4.specfile.bin