### PR TITLE
backhand: Improve performance

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -32,8 +32,7 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.targets }}
-      - run: cargo install cargo-quickinstall
-      - run: cargo quickinstall cross@0.2.5 --force
+      - run: RUSTFLAGS="-C target-feature=-crt-static" cargo install cross --git https://github.com/cross-rs/cross
       - run: cross build -p backhand-cli --bin add-backhand --bin replace-backhand --locked --target ${{ matrix.targets }} --profile=dist
       # default features, but replace gzip with gzip-zune-inflate
       - run: cross build -p backhand-cli --bin unsquashfs-backhand --locked --target ${{ matrix.targets }} --profile=dist --no-default-features --features zstd,xz,gzip-zune-inflate

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
           toolchain: ${{ matrix.toolchain }}
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       # install cross
-      - run: cargo install cargo-quickinstall
-      - run: cargo quickinstall cross@0.2.5 --force
+      - run: RUSTFLAGS="-C target-feature=-crt-static" cargo install cross --git https://github.com/cross-rs/cross
       # build lib and bins with cross
       - run: cross build ${{ matrix.features }} --target ${{ matrix.target }} --release --locked --workspace
       # test with cross
@@ -79,8 +78,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       # install cross
-      - run: cargo install cargo-quickinstall
-      - run: cargo quickinstall cross@0.2.5 --force
+      - run: RUSTFLAGS="-C target-feature=-crt-static" cargo install cross --git https://github.com/cross-rs/cross
       # build bins
       - run: cross build ${{ matrix.features }} --target ${{ matrix.target }} --release --locked --workspace
       # run tests with native unsquashfs on x86_64-unknown-linux-musl (using Cross.toml)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ name: ci
 
 jobs:
   # build/test all supported targets for library and bins (skipping slow and squashfs-tools tests)
-  build-test:
+  cross-test:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C target-feature=+crt-static"
@@ -47,8 +47,8 @@ jobs:
       - run: RUSTFLAGS="-C target-feature=-crt-static" cargo install cross --git https://github.com/cross-rs/cross
       # build lib and bins with cross
       - run: cross build ${{ matrix.features }} --target ${{ matrix.target }} --release --locked --workspace
-      # test with cross
-      - run: CROSS_CONTAINER_OPTS="--network host" RUST_LOG=info cross test --workspace --release ${{ matrix.features }} --target ${{ matrix.target }} --locked -- --skip slow
+      # test with cross, skipping slow test and tests that use more then qemu default memory
+      - run: CROSS_CONTAINER_OPTS="--network host" RUST_LOG=info cross test --workspace --release ${{ matrix.features }} --target ${{ matrix.target }} --locked -- --skip slow --skip no_qemu
 
   # build/test all supported on native(musl) arch for library and bins (all tests)
   build-test-native:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,14 +50,12 @@ jobs:
       # test with cross, skipping slow test and tests that use more then qemu default memory
       - run: CROSS_CONTAINER_OPTS="--network host" RUST_LOG=info cross test --workspace --release ${{ matrix.features }} --target ${{ matrix.target }} --locked -- --skip slow --skip no_qemu
 
-  # build/test all supported on native(musl) arch for library and bins (all tests)
+  # build/test all supported on native x86_64 arch for library and bins (all tests)
   build-test-native:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-musl
         toolchain:
           - stable
             # msrv of backhand-cli
@@ -77,12 +75,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248 # master
         with:
           toolchain: ${{ matrix.toolchain }}
-      # install cross
-      - run: RUSTFLAGS="-C target-feature=-crt-static" cargo install cross --git https://github.com/cross-rs/cross
       # build bins
-      - run: cross build ${{ matrix.features }} --target ${{ matrix.target }} --release --locked --workspace
+      - run: cargo build ${{ matrix.features }} --release --locked --workspace
       # run tests with native unsquashfs on x86_64-unknown-linux-musl (using Cross.toml)
-      - run: CROSS_CONTAINER_OPTS="--network host" RUST_LOG=info cross test --workspace --release ${{ matrix.features }} --target ${{ matrix.target }} --locked --features __test_unsquashfs -- --skip slow
+      - run: RUST_LOG=info cargo test --workspace --release ${{ matrix.features }}  --locked --features __test_unsquashfs -- --skip slow
 
   # fmt and clippy on stable
   fmt-clippy-stable:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -34,6 +34,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - run: cargo install cargo-quickinstall
-      - run: cargo quickinstall cross@0.2.5 --force
+      - run: cargo install cross --git https://github.com/cross-rs/cross
       - run: cross check --all-features --target ${{ matrix.target }} --locked -p backhand

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -11,17 +11,9 @@ name: Check MSRV of backhand
 jobs:
   build-test:
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-C target-feature=+crt-static"
     strategy:
-      # By default, this is set to `true`, which means that a single CI job
-      # failure will cause all outstanding jobs to be canceled. This slows down
-      # development because it means that errors need to be encountered and
-      # fixed one at a time.
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-musl
         toolchain:
             # msrv of backhand
           - 1.67.1
@@ -34,5 +26,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - run: cargo install cross --git https://github.com/cross-rs/cross
-      - run: cross check --all-features --target ${{ matrix.target }} --locked -p backhand
+      - run: cargo check --all-features --locked -p backhand

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -42,52 +42,52 @@ $ ./bench.bash
 ## Wall time: `backhand/unsquashfs-master` vs `squashfs-tools/unsquashfs-4.6.1`
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-v0.14.2-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 177.3 ± 10.0 | 165.3 | 219.7 | 1.06 ± 0.08 |
-| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 195.8 ± 10.6 | 182.9 | 236.5 | 1.17 ± 0.08 |
-| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 175.2 ± 16.5 | 163.7 | 264.5 | 1.05 ± 0.11 |
-| `squashfs-tools-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 166.8 ± 7.5 | 153.7 | 188.3 | 1.00 |
+| `backhand-dist-v0.14.2-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 173.9 ± 4.4 | 165.5 | 192.6 | 1.05 ± 0.04 |
+| `backhand-dist-musl-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 190.6 ± 5.0 | 180.8 | 203.1 | 1.15 ± 0.05 |
+| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 168.0 ± 4.5 | 162.3 | 185.3 | 1.01 ± 0.04 |
+| `squashfs-tools-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 165.9 ± 5.7 | 157.2 | 179.9 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-v0.14.2--openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 177.4 ± 5.4 | 170.1 | 190.5 | 1.12 ± 0.07 |
-| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 193.9 ± 6.9 | 187.7 | 232.1 | 1.22 ± 0.08 |
-| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 170.1 ± 5.4 | 163.9 | 189.2 | 1.07 ± 0.06 |
-| `squashfs-tools-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 159.0 ± 8.1 | 149.5 | 179.2 | 1.00 |
+| `backhand-dist-v0.14.2-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 175.3 ± 5.5 | 166.7 | 196.8 | 1.09 ± 0.06 |
+| `backhand-dist-musl-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 192.2 ± 3.9 | 187.6 | 205.5 | 1.19 ± 0.06 |
+| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 170.3 ± 5.0 | 154.7 | 182.1 | 1.06 ± 0.06 |
+| `squashfs-tools-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 161.0 ± 7.0 | 148.8 | 179.1 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-v0.14.2-870D97.squashfs` | 841.3 ± 20.1 | 793.6 | 868.3 | 1.26 ± 0.03 |
-| `backhand-dist-870D97.squashfs` | 963.6 ± 24.0 | 921.0 | 1019.6 | 1.44 ± 0.04 |
-| `backhand-dist-870D97.squashfs` | 833.1 ± 24.7 | 791.7 | 883.8 | 1.25 ± 0.04 |
-| `squashfs-tools-870D97.squashfs` | 667.1 ± 4.8 | 660.4 | 675.2 | 1.00 |
+| `backhand-dist-v0.14.2-870D97.squashfs` | 837.4 ± 22.2 | 795.5 | 868.1 | 1.25 ± 0.03 |
+| `backhand-dist-musl-870D97.squashfs` | 970.6 ± 26.0 | 927.2 | 1022.3 | 1.45 ± 0.04 |
+| `backhand-dist-870D97.squashfs` | 835.1 ± 24.8 | 790.3 | 883.6 | 1.25 ± 0.04 |
+| `squashfs-tools-870D97.squashfs` | 668.6 ± 4.1 | 663.1 | 675.4 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-v0.14.2-img-1571203182_vol-ubi_rootfs.ubifs` | 905.3 ± 15.7 | 891.8 | 995.9 | 1.01 ± 0.03 |
-| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 1014.2 ± 12.0 | 995.1 | 1048.1 | 1.13 ± 0.04 |
-| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 895.2 ± 26.2 | 870.3 | 1006.7 | 1.00 |
-| `squashfs-tools-img-1571203182_vol-ubi_rootfs.ubifs` | 929.4 ± 12.3 | 910.3 | 965.6 | 1.04 ± 0.03 |
+| `backhand-dist-v0.14.2-img-1571203182_vol-ubi_rootfs.ubifs` | 911.9 ± 30.4 | 887.1 | 1053.4 | 1.02 ± 0.04 |
+| `backhand-dist-musl-img-1571203182_vol-ubi_rootfs.ubifs` | 1016.6 ± 16.2 | 994.2 | 1066.0 | 1.14 ± 0.03 |
+| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 891.5 ± 20.1 | 868.4 | 1013.3 | 1.00 |
+| `squashfs-tools-img-1571203182_vol-ubi_rootfs.ubifs` | 928.6 ± 13.0 | 900.9 | 958.0 | 1.04 ± 0.03 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-v0.14.2-2611E3.squashfs` | 422.5 ± 15.1 | 398.4 | 466.1 | 1.05 ± 0.06 |
-| `backhand-dist-2611E3.squashfs` | 461.3 ± 26.6 | 429.5 | 508.8 | 1.15 ± 0.09 |
-| `backhand-dist-2611E3.squashfs` | 402.0 ± 19.7 | 376.2 | 447.8 | 1.00 |
-| `squashfs-tools-2611E3.squashfs` | 447.2 ± 12.2 | 416.8 | 469.5 | 1.11 ± 0.06 |
+| `backhand-dist-v0.14.2-2611E3.squashfs` | 425.6 ± 12.8 | 403.5 | 455.3 | 1.07 ± 0.06 |
+| `backhand-dist-musl-2611E3.squashfs` | 462.9 ± 25.4 | 432.7 | 509.2 | 1.16 ± 0.08 |
+| `backhand-dist-2611E3.squashfs` | 399.1 ± 19.1 | 378.3 | 448.5 | 1.00 |
+| `squashfs-tools-2611E3.squashfs` | 447.8 ± 15.7 | 416.4 | 479.7 | 1.12 ± 0.07 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-v0.14.2-Plexamp-4.6.1.AppImage` | 726.9 ± 10.0 | 705.8 | 750.8 | 1.41 ± 0.02 |
-| `backhand-dist-Plexamp-4.6.1.AppImage` | 1345.6 ± 12.3 | 1318.9 | 1372.9 | 2.60 ± 0.03 |
-| `backhand-dist-Plexamp-4.6.1.AppImage` | 761.9 ± 9.6 | 735.7 | 780.4 | 1.47 ± 0.02 |
-| `squashfs-tools-Plexamp-4.6.1.AppImage` | 516.7 ± 4.3 | 509.6 | 527.9 | 1.00 |
+| `backhand-dist-v0.14.2-Plexamp-4.6.1.AppImage` | 724.5 ± 11.1 | 697.6 | 753.0 | 1.40 ± 0.03 |
+| `backhand-dist-musl-Plexamp-4.6.1.AppImage` | 1344.0 ± 17.4 | 1310.8 | 1375.2 | 2.60 ± 0.04 |
+| `backhand-dist-Plexamp-4.6.1.AppImage` | 760.9 ± 13.0 | 733.5 | 788.9 | 1.47 ± 0.03 |
+| `squashfs-tools-Plexamp-4.6.1.AppImage` | 516.6 ± 4.8 | 505.1 | 526.6 | 1.00 |
 
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-v0.14.2-crates-io.squashfs` | 67.632 ± 0.266 | 66.927 | 68.240 | 27.68 ± 0.35 |
-| `backhand-dist-crates-io.squashfs` | 2.444 ± 0.030 | 2.398 | 2.540 | 1.00 |
-| `backhand-dist-crates-io.squashfs` | 2.519 ± 0.013 | 2.488 | 2.555 | 1.03 ± 0.01 |
-| `squashfs-tools-crates-io.squashfs` | 2.519 ± 0.060 | 2.393 | 2.639 | 1.03 ± 0.03 |
+| `backhand-dist-v0.14.2-crates-io.squashfs` | 69.386 ± 0.968 | 67.132 | 71.444 | 28.22 ± 0.47 |
+| `backhand-dist-musl-crates-io.squashfs` | 2.458 ± 0.023 | 2.432 | 2.526 | 1.00 |
+| `backhand-dist-crates-io.squashfs` | 2.539 ± 0.018 | 2.507 | 2.620 | 1.03 ± 0.01 |
+| `squashfs-tools-crates-io.squashfs` | 2.521 ± 0.057 | 2.386 | 2.668 | 1.03 ± 0.03 |
 
 ## Heap Usage: `backhand/unsquashfs-master` vs `squashfs-tools/unsquashfs-4.6.1`
 ```

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -42,39 +42,45 @@ $ ./bench.bash
 ## Wall time: `backhand/unsquashfs-master` vs `squashfs-tools/unsquashfs-4.6.1`
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 205.4 ± 6.0 | 190.5 | 220.8 | 1.17 ± 0.06 |
-| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 184.8 ± 4.7 | 176.4 | 196.3 | 1.05 ± 0.06 |
-| `squashfs-tools-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 176.3 ± 8.2 | 162.6 | 205.3 | 1.00 |
+| `backhand-dist-musl-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 189.9 ± 3.9 | 183.0 | 199.7 | 1.15 ± 0.06 |
+| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 167.4 ± 3.8 | 162.0 | 177.6 | 1.01 ± 0.05 |
+| `squashfs-tools-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 165.0 ± 7.5 | 151.8 | 185.5 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 209.7 ± 11.5 | 197.5 | 255.4 | 1.25 ± 0.09 |
-| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 189.5 ± 8.3 | 171.3 | 212.3 | 1.13 ± 0.07 |
-| `squashfs-tools-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 167.2 ± 7.1 | 156.0 | 194.7 | 1.00 |
-
-| Command | Mean [s] | Min [s] | Max [s] | Relative |
-|:---|---:|---:|---:|---:|
-| `backhand-dist-musl-870D97.squashfs` | 1.029 ± 0.035 | 0.963 | 1.095 | 1.44 ± 0.05 |
-| `backhand-dist-870D97.squashfs` | 0.900 ± 0.023 | 0.838 | 0.946 | 1.26 ± 0.03 |
-| `squashfs-tools-870D97.squashfs` | 0.716 ± 0.002 | 0.712 | 0.721 | 1.00 |
-
-| Command | Mean [s] | Min [s] | Max [s] | Relative |
-|:---|---:|---:|---:|---:|
-| `backhand-dist-musl-img-1571203182_vol-ubi_rootfs.ubifs` | 1.121 ± 0.047 | 1.073 | 1.291 | 1.18 ± 0.05 |
-| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 1.003 ± 0.078 | 0.920 | 1.293 | 1.06 ± 0.08 |
-| `squashfs-tools-img-1571203182_vol-ubi_rootfs.ubifs` | 0.949 ± 0.016 | 0.923 | 0.997 | 1.00 |
+| `backhand-dist-musl-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 191.8 ± 3.7 | 185.8 | 203.9 | 1.21 ± 0.05 |
+| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 170.5 ± 5.2 | 163.4 | 185.4 | 1.07 ± 0.05 |
+| `squashfs-tools-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 158.8 ± 6.2 | 147.3 | 178.0 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-2611E3.squashfs` | 477.5 ± 21.9 | 446.3 | 528.8 | 1.12 ± 0.07 |
-| `backhand-dist-2611E3.squashfs` | 425.8 ± 15.7 | 396.4 | 472.3 | 1.00 |
-| `squashfs-tools-2611E3.squashfs` | 453.5 ± 16.1 | 425.1 | 496.6 | 1.07 ± 0.05 |
+| `backhand-dist-musl-870D97.squashfs` | 969.4 ± 28.3 | 919.4 | 1019.1 | 1.46 ± 0.04 |
+| `backhand-dist-870D97.squashfs` | 834.9 ± 25.9 | 790.0 | 877.4 | 1.25 ± 0.04 |
+| `squashfs-tools-870D97.squashfs` | 666.3 ± 3.5 | 660.3 | 672.7 | 1.00 |
 
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-Plexamp-4.6.1.AppImage` | 1.264 ± 0.014 | 1.236 | 1.297 | 2.41 ± 0.07 |
-| `backhand-dist-Plexamp-4.6.1.AppImage` | 0.718 ± 0.010 | 0.698 | 0.745 | 1.37 ± 0.04 |
-| `squashfs-tools-Plexamp-4.6.1.AppImage` | 0.524 ± 0.015 | 0.514 | 0.603 | 1.00 |
+| `backhand-dist-musl-img-1571203182_vol-ubi_rootfs.ubifs` | 1.013 ± 0.014 | 0.994 | 1.054 | 1.14 ± 0.02 |
+| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 0.890 ± 0.011 | 0.869 | 0.927 | 1.00 |
+| `squashfs-tools-img-1571203182_vol-ubi_rootfs.ubifs` | 0.928 ± 0.015 | 0.896 | 0.955 | 1.04 ± 0.02 |
+
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `backhand-dist-musl-2611E3.squashfs` | 466.0 ± 26.3 | 428.9 | 505.5 | 1.15 ± 0.09 |
+| `backhand-dist-2611E3.squashfs` | 404.1 ± 22.1 | 382.8 | 446.9 | 1.00 |
+| `squashfs-tools-2611E3.squashfs` | 447.8 ± 15.7 | 410.5 | 479.9 | 1.11 ± 0.07 |
+
+| Command | Mean [s] | Min [s] | Max [s] | Relative |
+|:---|---:|---:|---:|---:|
+| `backhand-dist-musl-Plexamp-4.6.1.AppImage` | 1.351 ± 0.011 | 1.317 | 1.368 | 2.65 ± 0.04 |
+| `backhand-dist-Plexamp-4.6.1.AppImage` | 0.744 ± 0.011 | 0.721 | 0.768 | 1.46 ± 0.03 |
+| `squashfs-tools-Plexamp-4.6.1.AppImage` | 0.509 ± 0.006 | 0.502 | 0.536 | 1.00 |
+
+| Command | Mean [s] | Min [s] | Max [s] | Relative |
+|:---|---:|---:|---:|---:|
+| `backhand-dist-musl-crates-io.squashfs` | 2.520 ± 0.015 | 2.499 | 2.567 | 1.00 |
+| `backhand-dist-crates-io.squashfs` | 2.523 ± 0.038 | 2.495 | 2.778 | 1.00 ± 0.02 |
+| `squashfs-tools-crates-io.squashfs` | 2.526 ± 0.064 | 2.396 | 2.664 | 1.00 ± 0.03 |
 
 ## Heap Usage: `backhand/unsquashfs-master` vs `squashfs-tools/unsquashfs-4.6.1`
 ```

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -42,45 +42,52 @@ $ ./bench.bash
 ## Wall time: `backhand/unsquashfs-master` vs `squashfs-tools/unsquashfs-4.6.1`
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 189.9 ± 3.9 | 183.0 | 199.7 | 1.15 ± 0.06 |
-| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 167.4 ± 3.8 | 162.0 | 177.6 | 1.01 ± 0.05 |
-| `squashfs-tools-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 165.0 ± 7.5 | 151.8 | 185.5 | 1.00 |
+| `backhand-dist-v0.14.2-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 177.3 ± 10.0 | 165.3 | 219.7 | 1.06 ± 0.08 |
+| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 195.8 ± 10.6 | 182.9 | 236.5 | 1.17 ± 0.08 |
+| `backhand-dist-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 175.2 ± 16.5 | 163.7 | 264.5 | 1.05 ± 0.11 |
+| `squashfs-tools-openwrt-22.03.2-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin` | 166.8 ± 7.5 | 153.7 | 188.3 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 191.8 ± 3.7 | 185.8 | 203.9 | 1.21 ± 0.05 |
-| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 170.5 ± 5.2 | 163.4 | 185.4 | 1.07 ± 0.05 |
-| `squashfs-tools-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 158.8 ± 6.2 | 147.3 | 178.0 | 1.00 |
+| `backhand-dist-v0.14.2--openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 177.4 ± 5.4 | 170.1 | 190.5 | 1.12 ± 0.07 |
+| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 193.9 ± 6.9 | 187.7 | 232.1 | 1.22 ± 0.08 |
+| `backhand-dist-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 170.1 ± 5.4 | 163.9 | 189.2 | 1.07 ± 0.06 |
+| `squashfs-tools-openwrt-22.03.2-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img` | 159.0 ± 8.1 | 149.5 | 179.2 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-870D97.squashfs` | 969.4 ± 28.3 | 919.4 | 1019.1 | 1.46 ± 0.04 |
-| `backhand-dist-870D97.squashfs` | 834.9 ± 25.9 | 790.0 | 877.4 | 1.25 ± 0.04 |
-| `squashfs-tools-870D97.squashfs` | 666.3 ± 3.5 | 660.3 | 672.7 | 1.00 |
-
-| Command | Mean [s] | Min [s] | Max [s] | Relative |
-|:---|---:|---:|---:|---:|
-| `backhand-dist-musl-img-1571203182_vol-ubi_rootfs.ubifs` | 1.013 ± 0.014 | 0.994 | 1.054 | 1.14 ± 0.02 |
-| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 0.890 ± 0.011 | 0.869 | 0.927 | 1.00 |
-| `squashfs-tools-img-1571203182_vol-ubi_rootfs.ubifs` | 0.928 ± 0.015 | 0.896 | 0.955 | 1.04 ± 0.02 |
+| `backhand-dist-v0.14.2-870D97.squashfs` | 841.3 ± 20.1 | 793.6 | 868.3 | 1.26 ± 0.03 |
+| `backhand-dist-870D97.squashfs` | 963.6 ± 24.0 | 921.0 | 1019.6 | 1.44 ± 0.04 |
+| `backhand-dist-870D97.squashfs` | 833.1 ± 24.7 | 791.7 | 883.8 | 1.25 ± 0.04 |
+| `squashfs-tools-870D97.squashfs` | 667.1 ± 4.8 | 660.4 | 675.2 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-2611E3.squashfs` | 466.0 ± 26.3 | 428.9 | 505.5 | 1.15 ± 0.09 |
-| `backhand-dist-2611E3.squashfs` | 404.1 ± 22.1 | 382.8 | 446.9 | 1.00 |
-| `squashfs-tools-2611E3.squashfs` | 447.8 ± 15.7 | 410.5 | 479.9 | 1.11 ± 0.07 |
+| `backhand-dist-v0.14.2-img-1571203182_vol-ubi_rootfs.ubifs` | 905.3 ± 15.7 | 891.8 | 995.9 | 1.01 ± 0.03 |
+| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 1014.2 ± 12.0 | 995.1 | 1048.1 | 1.13 ± 0.04 |
+| `backhand-dist-img-1571203182_vol-ubi_rootfs.ubifs` | 895.2 ± 26.2 | 870.3 | 1006.7 | 1.00 |
+| `squashfs-tools-img-1571203182_vol-ubi_rootfs.ubifs` | 929.4 ± 12.3 | 910.3 | 965.6 | 1.04 ± 0.03 |
+
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `backhand-dist-v0.14.2-2611E3.squashfs` | 422.5 ± 15.1 | 398.4 | 466.1 | 1.05 ± 0.06 |
+| `backhand-dist-2611E3.squashfs` | 461.3 ± 26.6 | 429.5 | 508.8 | 1.15 ± 0.09 |
+| `backhand-dist-2611E3.squashfs` | 402.0 ± 19.7 | 376.2 | 447.8 | 1.00 |
+| `squashfs-tools-2611E3.squashfs` | 447.2 ± 12.2 | 416.8 | 469.5 | 1.11 ± 0.06 |
+
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `backhand-dist-v0.14.2-Plexamp-4.6.1.AppImage` | 726.9 ± 10.0 | 705.8 | 750.8 | 1.41 ± 0.02 |
+| `backhand-dist-Plexamp-4.6.1.AppImage` | 1345.6 ± 12.3 | 1318.9 | 1372.9 | 2.60 ± 0.03 |
+| `backhand-dist-Plexamp-4.6.1.AppImage` | 761.9 ± 9.6 | 735.7 | 780.4 | 1.47 ± 0.02 |
+| `squashfs-tools-Plexamp-4.6.1.AppImage` | 516.7 ± 4.3 | 509.6 | 527.9 | 1.00 |
 
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `backhand-dist-musl-Plexamp-4.6.1.AppImage` | 1.351 ± 0.011 | 1.317 | 1.368 | 2.65 ± 0.04 |
-| `backhand-dist-Plexamp-4.6.1.AppImage` | 0.744 ± 0.011 | 0.721 | 0.768 | 1.46 ± 0.03 |
-| `squashfs-tools-Plexamp-4.6.1.AppImage` | 0.509 ± 0.006 | 0.502 | 0.536 | 1.00 |
-
-| Command | Mean [s] | Min [s] | Max [s] | Relative |
-|:---|---:|---:|---:|---:|
-| `backhand-dist-musl-crates-io.squashfs` | 2.520 ± 0.015 | 2.499 | 2.567 | 1.00 |
-| `backhand-dist-crates-io.squashfs` | 2.523 ± 0.038 | 2.495 | 2.778 | 1.00 ± 0.02 |
-| `squashfs-tools-crates-io.squashfs` | 2.526 ± 0.064 | 2.396 | 2.664 | 1.00 ± 0.03 |
+| `backhand-dist-v0.14.2-crates-io.squashfs` | 67.632 ± 0.266 | 66.927 | 68.240 | 27.68 ± 0.35 |
+| `backhand-dist-crates-io.squashfs` | 2.444 ± 0.030 | 2.398 | 2.540 | 1.00 |
+| `backhand-dist-crates-io.squashfs` | 2.519 ± 0.013 | 2.488 | 2.555 | 1.03 ± 0.01 |
+| `squashfs-tools-crates-io.squashfs` | 2.519 ± 0.060 | 2.393 | 2.639 | 1.03 ± 0.03 |
 
 ## Heap Usage: `backhand/unsquashfs-master` vs `squashfs-tools/unsquashfs-4.6.1`
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "tracing",
  "xz2",
  "zstd",
+ "zstd-safe",
  "zune-inflate",
 ]
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,8 @@
 [target.x86_64-unknown-linux-musl]
-pre-build = ["apt-get update && apt-get install --assume-yes squashfs-tools"]
+pre-build = [
+    "apt update && apt install zlib1g-dev liblzma-dev",
+    "git clone https://github.com/plougher/squashfs-tools.git -b squashfs-tools-4.6.1 && cd squashfs-tools/squashfs-tools && CONFIG=1 XZ_SUPPORT=1 GZIP_SUPPORT=1 make && make install",
+]
 
 [build.env]
 passthrough = [

--- a/backhand-test/tests/add.rs
+++ b/backhand-test/tests/add.rs
@@ -106,19 +106,21 @@ fn test_add() {
 
     #[cfg(feature = "__test_unsquashfs")]
     {
+        let dir = tmp_dir.path().join("out2");
         let output = Command::new("unsquashfs")
-            .args(["-lln", "-UTC", tmp_dir.path().join("out2").to_str().unwrap()])
+            .args(["-lln", "-UTC", dir.to_str().unwrap()])
             .output()
             .unwrap();
         let expected = r#"drwxr-xr-x 1000/1000                36 2022-10-14 03:02 squashfs-root
 drwxr-xr-x 1000/1000                24 2022-10-14 03:02 squashfs-root/b
 drwxr-xr-x 1000/1000                24 2022-10-14 03:03 squashfs-root/b/c
--rw-r--r-- 1000/1000                39 2022-10-14 03:03 squashfs-root/b/c/d
+-rw-r--r-- 1000/1000                43 2022-10-14 03:03 squashfs-root/b/c/d
 dr----x--t 2/4242                   42 1970-01-01 00:01 squashfs-root/test
 -rw-r--r-- 4242/2               262144 1970-01-01 00:02 squashfs-root/test/big_file
--rw-r--r-- 4242/2                    4 1970-01-01 00:02 squashfs-root/test/new"#;
+-rw-r--r-- 4242/2                   43 1970-01-01 00:02 squashfs-root/test/new
+"#;
 
         // using contains here, the output of squashfs varies between versions
-        assert!(std::str::from_utf8(&output.stdout).unwrap().contains(expected));
+        assert_eq!(std::str::from_utf8(&output.stdout).unwrap(), expected);
     }
 }

--- a/backhand-test/tests/add.rs
+++ b/backhand-test/tests/add.rs
@@ -114,10 +114,10 @@ fn test_add() {
         let expected = r#"drwxr-xr-x 1000/1000                36 2022-10-14 03:02 squashfs-root
 drwxr-xr-x 1000/1000                24 2022-10-14 03:02 squashfs-root/b
 drwxr-xr-x 1000/1000                24 2022-10-14 03:03 squashfs-root/b/c
--rw-r--r-- 1000/1000                43 2022-10-14 03:03 squashfs-root/b/c/d
+-rw-r--r-- 1000/1000                39 2022-10-14 03:03 squashfs-root/b/c/d
 dr----x--t 2/4242                   42 1970-01-01 00:01 squashfs-root/test
 -rw-r--r-- 4242/2               262144 1970-01-01 00:02 squashfs-root/test/big_file
--rw-r--r-- 4242/2                   43 1970-01-01 00:02 squashfs-root/test/new
+-rw-r--r-- 4242/2                    4 1970-01-01 00:02 squashfs-root/test/new
 "#;
 
         // using contains here, the output of squashfs varies between versions

--- a/backhand-test/tests/test.rs
+++ b/backhand-test/tests/test.rs
@@ -501,3 +501,18 @@ fn test_socket_fifo() {
         only_read(&asset_defs, FILE_NAME, TEST_PATH, 0);
     }
 }
+
+#[test]
+#[cfg(any(feature = "zstd"))]
+fn test_crates_zstd() {
+    const FILE_NAME: &str = "crates-io.squashfs";
+    let asset_defs = [TestAssetDef {
+        filename: FILE_NAME.to_string(),
+        hash: "f9d9938626c6cade032a3e54ce9e16fbabaf9e0cb6a0eb486c5c189d7fb9d13d".to_string(),
+        url: format!("https://wcampbell.dev/squashfs/testing/crates.io-zstd/{FILE_NAME}"),
+    }];
+
+    const TEST_PATH: &str = "test-assets/crates_io_zstd";
+
+    full_test(&asset_defs, FILE_NAME, TEST_PATH, 0, Verify::Extract, false);
+}

--- a/backhand-test/tests/test.rs
+++ b/backhand-test/tests/test.rs
@@ -79,8 +79,6 @@ fn full_test_inner(
     new_filesystem.write_with_offset(&mut output, offset).unwrap();
     info!("done with writing to bytes");
 
-    // Test Debug is impl'ed properly on FilesystemWriter
-    let _ = format!("{new_filesystem:#02x?}");
     drop(new_filesystem);
     drop(og_filesystem);
 

--- a/backhand-test/tests/test.rs
+++ b/backhand-test/tests/test.rs
@@ -506,7 +506,8 @@ fn test_socket_fifo() {
 
 #[test]
 #[cfg(any(feature = "zstd"))]
-fn test_crates_zstd() {
+fn no_qemu_test_crates_zstd() {
+    tracing::trace!("nice");
     const FILE_NAME: &str = "crates-io.squashfs";
     let asset_defs = [TestAssetDef {
         filename: FILE_NAME.to_string(),

--- a/backhand-test/tests/test.rs
+++ b/backhand-test/tests/test.rs
@@ -77,9 +77,12 @@ fn full_test_inner(
     info!("calling to_bytes");
     let mut output = BufWriter::new(File::create(&new_path).unwrap());
     new_filesystem.write_with_offset(&mut output, offset).unwrap();
+    info!("done with writing to bytes");
 
     // Test Debug is impl'ed properly on FilesystemWriter
     let _ = format!("{new_filesystem:#02x?}");
+    drop(new_filesystem);
+    drop(og_filesystem);
 
     // assert that our library can at least read the output, use unsquashfs to really assert this
     info!("calling from_reader");
@@ -91,6 +94,7 @@ fn full_test_inner(
     let new_comp_opts = written_new_filesystem.compression_options;
     assert_eq!(og_comp_opts, new_comp_opts);
 
+    drop(written_new_filesystem);
     match verify {
         Verify::Extract => {
             if run_squashfs_tools_unsquashfs {

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 deku = "0.16.0"
-tracing = { version = "0.1.40", features = ["release_max_level_off"] }
+tracing = { version = "0.1.40", features = ["release_max_level_info"] }
 thiserror = "1.0.58"
 flate2 = { version = "1.0.28", optional = true }
 zune-inflate = { version = "0.2.54", optional = true, default-features = false, features = ["zlib"] }

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 deku = "0.16.0"
-tracing = { version = "0.1.40", features = ["release_max_level_info"] }
+tracing = { version = "0.1.40" }
 thiserror = "1.0.58"
 flate2 = { version = "1.0.28", optional = true }
 zune-inflate = { version = "0.2.54", optional = true, default-features = false, features = ["zlib"] }

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -20,6 +20,7 @@ zune-inflate = { version = "0.2.54", optional = true, default-features = false, 
 xz2 = { version = "0.1.7", optional = true }
 rust-lzo = { version = "0.6.2", optional = true }
 zstd = { version = "0.13.0", optional = true }
+zstd-safe = { version = "7.0.0", optional = true }
 rustc-hash = "1.1.0"
 document-features = { version = "0.2.8", optional = true }
 
@@ -37,7 +38,7 @@ gzip-zune-inflate = ["dep:zune-inflate"]
 ## This library is licensed GPL and thus disabled by default
 lzo = ["dep:rust-lzo"]
 ## Enables zstd compression inside library and binaries
-zstd = ["dep:zstd"]
+zstd = ["dep:zstd", "dep:zstd-safe"]
 
 [dev-dependencies]
 test-log = { version = "0.2.15", features = ["trace"] }

--- a/backhand/src/compressor.rs
+++ b/backhand/src/compressor.rs
@@ -328,7 +328,8 @@ impl CompressionAction for DefaultCompressor {
                     Some(_) => unreachable!(),
                 };
                 let mut encoder = zstd::bulk::Compressor::new(compression_level as i32)?;
-                let mut buf = vec![];
+                let buffer_len = zstd_safe::compress_bound(bytes.len());
+                let mut buf = Vec::with_capacity(buffer_len);
                 encoder.compress_to_buffer(bytes, &mut buf)?;
                 Ok(buf)
             }

--- a/backhand/src/data.rs
+++ b/backhand/src/data.rs
@@ -18,6 +18,7 @@ const DATA_STORED_UNCOMPRESSED: u32 = 1 << 24;
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 pub struct DataSize(u32);
 impl DataSize {
+    #[inline]
     pub fn new(size: u32, uncompressed: bool) -> Self {
         let mut value: u32 = size;
         if value > DATA_STORED_UNCOMPRESSED {
@@ -29,26 +30,32 @@ impl DataSize {
         Self(value)
     }
 
+    #[inline]
     pub fn new_compressed(size: u32) -> Self {
         Self::new(size, false)
     }
 
+    #[inline]
     pub fn new_uncompressed(size: u32) -> Self {
         Self::new(size, true)
     }
 
+    #[inline]
     pub fn uncompressed(&self) -> bool {
         self.0 & DATA_STORED_UNCOMPRESSED != 0
     }
 
+    #[inline]
     pub fn set_uncompressed(&mut self) {
         self.0 |= DATA_STORED_UNCOMPRESSED
     }
 
+    #[inline]
     pub fn set_compressed(&mut self) {
         self.0 &= !DATA_STORED_UNCOMPRESSED
     }
 
+    #[inline]
     pub fn size(&self) -> u32 {
         self.0 & !DATA_STORED_UNCOMPRESSED
     }

--- a/backhand/src/filesystem/reader.rs
+++ b/backhand/src/filesystem/reader.rs
@@ -377,6 +377,7 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
         Ok(())
     }
 
+    #[inline]
     pub fn into_reader(
         self,
         buf_read: &'a mut Vec<u8>,
@@ -397,10 +398,12 @@ pub struct SquashfsReadFile<'a, 'b> {
 }
 
 impl<'a, 'b> SquashfsReadFile<'a, 'b> {
+    #[inline]
     fn available(&self) -> &[u8] {
         &self.buf_decompress[self.last_read..]
     }
 
+    #[inline]
     fn read_available(&mut self, buf: &mut [u8]) -> usize {
         let available = self.available();
         let read_len = buf.len().min(available.len()).min(self.bytes_available);
@@ -410,6 +413,7 @@ impl<'a, 'b> SquashfsReadFile<'a, 'b> {
         read_len
     }
 
+    #[inline]
     fn read_next_block(&mut self) -> Result<(), BackhandError> {
         let block = match self.raw_data.next_block(self.buf_read) {
             Some(block) => block?,
@@ -423,6 +427,7 @@ impl<'a, 'b> SquashfsReadFile<'a, 'b> {
 }
 
 impl<'a, 'b> Read for SquashfsReadFile<'a, 'b> {
+    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         // file was fully consumed
         if self.bytes_available == 0 {

--- a/backhand/src/filesystem/reader.rs
+++ b/backhand/src/filesystem/reader.rs
@@ -304,7 +304,7 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     if let Some(cache_bytes) = cache.fragment_cache.get(&fragment.start) {
                         //if in cache, just return the cache, don't read it
                         let range = self.fragment_range();
-                        tracing::info!("fragment in cache: {:02x}{range:?}", fragment.start);
+                        tracing::trace!("fragment in cache: {:02x}:{range:02x?}", fragment.start);
                         data.resize(range.end - range.start, 0);
                         data.copy_from_slice(&cache_bytes[range]);
 
@@ -316,7 +316,7 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                 // if not in the cache, read the entire fragment bytes to store into
                 // the cache. Once that is done, if uncompressed just return the bytes
                 // that were read that are for the file
-                tracing::info!("fragment: reading from data");
+                tracing::trace!("fragment: reading from data");
                 let frag_size = fragment.size.size() as usize;
                 data.resize(frag_size, 0);
                 {

--- a/backhand/src/reader.rs
+++ b/backhand/src/reader.rs
@@ -120,8 +120,8 @@ pub trait SquashFsReader: BufReadSeek {
         )?;
 
         let mut rest = bytes.view_bits::<deku::bitvec::Msb0>();
-        let mut inodes = HashMap::default();
-        inodes.try_reserve(min(superblock.inode_count as usize, 10000))?;
+        let mut inodes = FxHashMap::default();
+        inodes.try_reserve(superblock.inode_count as usize)?;
         while !rest.is_empty() {
             let (new_rest, i) = Inode::read(
                 rest,

--- a/backhand/src/reader.rs
+++ b/backhand/src/reader.rs
@@ -1,6 +1,5 @@
 //! Reader traits
 
-use std::cmp::min;
 use std::collections::HashMap;
 use std::io::{BufRead, Read, Seek, SeekFrom, Write};
 

--- a/backhand/src/squashfs.rs
+++ b/backhand/src/squashfs.rs
@@ -4,8 +4,8 @@ use std::ffi::OsString;
 use std::io::{Seek, SeekFrom};
 use std::os::unix::prelude::OsStringExt;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::{Arc, RwLock};
 
 use deku::bitvec::{BitVec, BitView, Msb0};
 use deku::prelude::*;
@@ -634,7 +634,7 @@ impl<'b> Squashfs<'b> {
             fragments: self.fragments,
             root,
             reader: Mutex::new(Box::new(self.file)),
-            cache: Mutex::new(Cache::default()),
+            cache: RwLock::new(Cache::default()),
         };
         Ok(filesystem)
     }

--- a/bench.bash
+++ b/bench.bash
@@ -18,8 +18,8 @@ bench () {
 }
 
 # Using dynamic linked xz for perf reasons and matching unsquashfs in this testing
-cross +stable build -p backhand-cli --bins --locked --target x86_64-unknown-linux-musl --profile=dist --no-default-features --features xz --features gzip-zune-inflate
-cargo +stable build -p backhand-cli --bins --locked --profile=dist --no-default-features --features xz --features gzip-zune-inflate
+cross +stable build -p backhand-cli --bins --locked --target x86_64-unknown-linux-musl --profile=dist --no-default-features --features xz --features gzip-zune-inflate --features zstd
+cargo +stable build -p backhand-cli --bins --locked --profile=dist --no-default-features --features xz --features gzip-zune-inflate --features zstd
 mkdir -p bench-results
 
 # xz
@@ -36,5 +36,7 @@ bench "backhand-test/test-assets/test_tplink_ax1800/img-1571203182_vol-ubi_rootf
 bench "backhand-test/test-assets/test_er605_v2_2/2611E3.squashfs" 0x0 4_er605
 # gzip
 bench "backhand-test/test-assets/test_appimage_plexamp/Plexamp-4.6.1.AppImage" 0x2dfe8 5_plexamp
+# zstd
+bench "backhand-test/test-assets/crates_io_zstd/crates-io.squashfs" 0x0 6_crates_zstd
 
 rm -rf /tmp/BH*

--- a/bench.bash
+++ b/bench.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+LAST_RELEASE="v0.14.2"
+
+BACKHAND_LAST_RELEASE="./last-release/bin/unsquashfs-backhand"
 BACKHAND="./target/dist/unsquashfs-backhand"
 BACKHAND_MUSL="./target/x86_64-unknown-linux-musl/dist/unsquashfs-backhand"
 UNSQUASHFS="/usr/bin/unsquashfs"
@@ -8,7 +11,9 @@ bench () {
     echo ""
     file $1
     hyperfine --runs 50 --warmup 10 \
-        --command-name backhand-dist-musl-$(basename $1) \
+        --command-name backhand-dist-${LAST_RELEASE}-$(basename $1) \
+        "$BACKHAND_LAST_RELEASE --quiet -f -d $(mktemp -d /tmp/BHXXX) -o $(rz-ax $2) $1" \
+        --command-name backhand-dist-$(basename $1) \
         "$BACKHAND_MUSL --quiet -f -d $(mktemp -d /tmp/BHXXX) -o $(rz-ax $2) $1" \
         --command-name backhand-dist-$(basename $1) \
         "$BACKHAND --quiet -f -d $(mktemp -d /tmp/BHXXX) -o $(rz-ax $2) $1" \
@@ -19,6 +24,7 @@ bench () {
 
 # Using dynamic linked xz for perf reasons and matching unsquashfs in this testing
 cross +stable build -p backhand-cli --bins --locked --target x86_64-unknown-linux-musl --profile=dist --no-default-features --features xz --features gzip-zune-inflate --features zstd
+cargo +stable install backhand-cli --git https://github.com/wcampbell0x2a/backhand.git --root last-release --tag "$LAST_RELEASE" --bins --locked --profile=dist --no-default-features --features xz --features gzip-zune-inflate --features zstd
 cargo +stable build -p backhand-cli --bins --locked --profile=dist --no-default-features --features xz --features gzip-zune-inflate --features zstd
 mkdir -p bench-results
 

--- a/bench.bash
+++ b/bench.bash
@@ -10,10 +10,10 @@ UNSQUASHFS="/usr/bin/unsquashfs"
 bench () {
     echo ""
     file $1
-    hyperfine --runs 50 --warmup 10 \
+    hyperfine --sort command --runs 50 --warmup 10 \
         --command-name backhand-dist-${LAST_RELEASE}-$(basename $1) \
         "$BACKHAND_LAST_RELEASE --quiet -f -d $(mktemp -d /tmp/BHXXX) -o $(rz-ax $2) $1" \
-        --command-name backhand-dist-$(basename $1) \
+        --command-name backhand-dist-musl-$(basename $1) \
         "$BACKHAND_MUSL --quiet -f -d $(mktemp -d /tmp/BHXXX) -o $(rz-ax $2) $1" \
         --command-name backhand-dist-$(basename $1) \
         "$BACKHAND --quiet -f -d $(mktemp -d /tmp/BHXXX) -o $(rz-ax $2) $1" \


### PR DESCRIPTION
- [backhand: Use RwLock for fragment cache](https://github.com/wcampbell0x2a/backhand/pull/504/commits/724c8c259dd76db8bc057f8d24b408bcce0d0785)
- [reader: Reduce copy_from_slice fragment amount](https://github.com/wcampbell0x2a/backhand/pull/504/commits/0a50fb24a4bd28fac2587e9d692f40bb0aeac93e)
- [unsquashfs: Add BufReader and BufWriter to io](https://github.com/wcampbell0x2a/backhand/pull/504/commits/0ac5b53b434d8a63e96aa2f89794718b539bfd1e)