### PR TITLE
Add any-gzip feature

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - run: cargo check --all-features --locked -p backhand
+      - run: cargo check --locked -p backhand

--- a/backhand-cli/Cargo.toml
+++ b/backhand-cli/Cargo.toml
@@ -37,10 +37,12 @@ default = ["xz", "gzip", "zstd"]
 xz = ["backhand/xz"]
 ## Enables xz compression and forces static build inside library and binaries
 xz-static = ["backhand/xz-static"]
+## Internal only
+any-gzip = ["backhand/any-gzip"]
 ## Enables gzip compression inside library and binaries
-gzip = ["backhand/gzip"]
+gzip = ["any-gzip","backhand/gzip"]
 ## Enables faster gzip de-compression only inside library and binaries
-gzip-zune-inflate = ["backhand/gzip-zune-inflate"]
+gzip-zune-inflate = ["any-gzip","backhand/gzip-zune-inflate"]
 ## This library is licensed GPL and thus disabled by default
 lzo = ["backhand/lzo"]
 ## Enables zstd compression inside library and binaries

--- a/backhand-cli/src/lib.rs
+++ b/backhand-cli/src/lib.rs
@@ -19,7 +19,7 @@ pub fn after_help(rayon_env: bool) -> String {
     let header = color_print::cstr!("<green, bold>Decompressors available:</>\n");
     s.push_str(header);
 
-    #[cfg(feature = "gzip")]
+    #[cfg(feature = "any-gzip")]
     s.push_str(color_print::cstr!("  <cyan, bold>gzip\n"));
 
     #[cfg(feature = "xz")]

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -30,11 +30,14 @@ default = ["xz", "gzip", "zstd"]
 xz = ["dep:xz2"]
 ## Enables xz compression and forces static build inside library and binaries
 xz-static = ["dep:xz2", "xz2?/static"]
-## Enables gzip compression inside library and binaries
-gzip = ["dep:flate2"]
-## Enables faster gzip (de-compression only) inside library and binaries
+## Internal only
+any-gzip = []
+## Enables gzip compression inside library and binaries using flate2 library
+## Cannot be used with the `gzip-zune-inflate` feature
+gzip = ["any-gzip", "dep:flate2"]
+## Enables faster gzip (de-compression only) inside library and binaries using zune-inflate
 ## Cannot be used with the `gzip` feature
-gzip-zune-inflate = ["dep:zune-inflate"]
+gzip-zune-inflate = ["any-gzip", "dep:zune-inflate"]
 ## This library is licensed GPL and thus disabled by default
 lzo = ["dep:rust-lzo"]
 ## Enables zstd compression inside library and binaries

--- a/backhand/src/compressor.rs
+++ b/backhand/src/compressor.rs
@@ -191,12 +191,12 @@ impl CompressionAction for DefaultCompressor {
     ) -> Result<(), BackhandError> {
         match compressor {
             Compressor::None => out.extend_from_slice(bytes),
-            #[cfg(all(feature = "gzip", not(feature = "gzip-zune-inflate")))]
+            #[cfg(feature = "gzip")]
             Compressor::Gzip => {
                 let mut decoder = flate2::read::ZlibDecoder::new(bytes);
                 decoder.read_to_end(out)?;
             }
-            #[cfg(all(feature = "gzip-zune-inflate", not(feature = "gzip")))]
+            #[cfg(feature = "gzip-zune-inflate")]
             Compressor::Gzip => {
                 use std::io::Write;
                 let mut decoder = zune_inflate::DeflateDecoder::new(&bytes);

--- a/backhand/src/lib.rs
+++ b/backhand/src/lib.rs
@@ -52,6 +52,9 @@
 //! # Features
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 
+#[cfg(all(feature = "gzip", feature = "gzip-zune-inflate"))]
+compile_error!("gzip and gzip-zune-inflate are mutually exclusive and cannot be enabled together");
+
 #[cfg(doctest)]
 #[doc = include_str!("../../README.md")]
 type _ReadmeTest = ();


### PR DESCRIPTION
* Fix bug in --help to correctly show support for gzip. Previously it would not show the correct help when gzip-zune-inflate was selected
* gzip and gzip-zune-inflate will give a compile-time error when selected together