### PR TITLE
Add non-standard CompressionOptions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase speed of internal `HashMap`s, by switching to `xxhash` and just using the `inode` as the key in other places.
 - Changed `SuperBlock::Flags` to be public.
 
+- Add non-standard CompressionOptions support ([#584](https://github.com/wcampbell0x2a/backhand/pull/584))
+  - Add `CompressionAction::compression_options` to override the default compression options emitted during writing.
+  - Add `FilesystemWriter::set_emit_compression_options`
+
 ### `backhand-cli`
+- Add `--no-compression-options` to `add` and `replace` to remove compression options from image after modification.
 - Add `--pad-len` to `replace` and `add` to control the length of end-of-image padding ([#604](https://github.com/wcampbell0x2a/backhand/pull/604))
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -106,16 +106,17 @@ Arguments:
   <FILE_PATH_IN_IMAGE>  Path of file once inserted into squashfs
 
 Options:
-  -d, --dir                Create empty directory
-  -f, --file <FILE>        Path of file to read, to write into squashfs
-  -o, --out <OUT>          Squashfs output image [default: added.squashfs]
-      --mode <MODE>        Override mode read from <FILE>
-      --uid <UID>          Override uid read from <FILE>
-      --gid <GID>          Override gid read from <FILE>
-      --mtime <MTIME>      Override mtime read from <FILE>
-      --pad-len <PAD_LEN>  Custom KiB padding length
-  -h, --help               Print help
-  -V, --version            Print version
+  -d, --dir                     Create empty directory
+  -f, --file <FILE>             Path of file to read, to write into squashfs
+  -o, --out <OUT>               Squashfs output image [default: added.squashfs]
+      --mode <MODE>             Override mode read from <FILE>
+      --uid <UID>               Override uid read from <FILE>
+      --gid <GID>               Override gid read from <FILE>
+      --mtime <MTIME>           Override mtime read from <FILE>
+      --pad-len <PAD_LEN>       Custom KiB padding length
+      --no-compression-options  Don't emit compression options
+  -h, --help                    Print help
+  -V, --version                 Print version
 ```
 
 ### replace-backhand
@@ -130,10 +131,11 @@ Arguments:
   <FILE_PATH_IN_IMAGE>  Path of file replaced in image
 
 Options:
-  -o, --out <OUT>          Squashfs output image [default: replaced.squashfs]
-      --pad-len <PAD_LEN>  Custom KiB padding length
-  -h, --help               Print help
-  -V, --version            Print version
+  -o, --out <OUT>               Squashfs output image [default: replaced.squashfs]
+      --pad-len <PAD_LEN>       Custom KiB padding length
+      --no-compression-options  Don't emit compression options
+  -h, --help                    Print help
+  -V, --version                 Print version
 ```
 
 ## Performance

--- a/backhand-cli/src/bin/add.rs
+++ b/backhand-cli/src/bin/add.rs
@@ -62,6 +62,10 @@ struct Args {
     /// Custom KiB padding length
     #[clap(long)]
     pad_len: Option<u32>,
+
+    /// Don't emit compression options
+    #[clap(long)]
+    no_compression_options: bool,
 }
 
 fn main() -> ExitCode {
@@ -109,6 +113,10 @@ fn main() -> ExitCode {
 
     if let Some(pad_len) = args.pad_len {
         filesystem.set_kib_padding(pad_len)
+    }
+
+    if args.no_compression_options {
+        filesystem.set_emit_compression_options(false);
     }
 
     // write new file

--- a/backhand-cli/src/bin/replace.rs
+++ b/backhand-cli/src/bin/replace.rs
@@ -39,6 +39,10 @@ struct Args {
     /// Custom KiB padding length
     #[clap(long)]
     pad_len: Option<u32>,
+
+    /// Don't emit compression options
+    #[clap(long)]
+    no_compression_options: bool,
 }
 
 fn main() -> ExitCode {
@@ -60,6 +64,9 @@ fn main() -> ExitCode {
 
     if let Some(pad_len) = args.pad_len {
         filesystem.set_kib_padding(pad_len)
+    }
+    if args.no_compression_options {
+        filesystem.set_emit_compression_options(false);
     }
 
     // write new file

--- a/backhand/src/kinds.rs
+++ b/backhand/src/kinds.rs
@@ -78,6 +78,7 @@ impl Kind {
     /// # Example
     /// ```rust
     /// # use backhand::{compression::Compressor, kind, FilesystemCompressor, kind::Kind, compression::CompressionAction, compression::DefaultCompressor, BackhandError};
+    /// # use backhand::SuperBlock;
     /// # use std::io::Write;
     /// #[derive(Copy, Clone)]
     /// pub struct CustomCompressor;
@@ -112,6 +113,16 @@ impl Kind {
     ///     ) -> Result<Vec<u8>, BackhandError> {
     ///         DefaultCompressor.compress(bytes, fc, block_size)
     ///     }
+    ///
+    ///    // pass the default options
+    ///    fn compression_options(
+    ///        &self,
+    ///        _superblock: &mut SuperBlock,
+    ///        _kind: &Kind,
+    ///        _fs_compressor: FilesystemCompressor,
+    ///    ) -> Result<Vec<u8>, BackhandError> {
+    ///        DefaultCompressor.compression_options(_superblock, _kind, _fs_compressor)
+    ///    }
     /// }
     ///
     /// let kind = Kind::new(&CustomCompressor);


### PR DESCRIPTION
* You ever wonder "what if a squashfs had custom compression options that I am forced to emit because the kernel is expecting this?". If this is you, then have fun with this addition! This allows one to implement compression_options for CompressionAction and emit.. whatever you want as the the compression option bytes.
* Change superblock struct in FilesystemWriter As Soon As Possible to make sure everything can just use those settings.
* Update tests to be un-padded for custom compression, easier to see the diff's with biodiff and such.