### PR TITLE
backhand: Remove duplicate data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tracing",
+ "xxhash-rust",
  "xz2",
  "zstd",
  "zstd-safe",
@@ -1890,6 +1891,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "xz2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
  "flate2",
  "libdeflater",
  "rust-lzo",
- "rustc-hash",
+ "solana-nohash-hasher",
  "tempfile",
  "test-assets",
  "test-log",
@@ -1145,12 +1145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
 name = "rustix"
 version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1271,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "solana-nohash-hasher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "spin"

--- a/backhand-test/tests/raw.rs
+++ b/backhand-test/tests/raw.rs
@@ -74,7 +74,7 @@ fn test_raw_00() {
             frag_count: 0x1,
             compressor: Compressor::Xz,
             block_log: 0x11,
-            flags: 0x0,
+            flags: backhand::Flags::DataHasBeenDeduplicated as u16,
             id_count: 0x2,
             version_major: 0x4,
             version_minor: 0x0,

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -25,9 +25,9 @@ xz2 = { version = "0.1.7", optional = true }
 rust-lzo = { version = "0.6.2", optional = true }
 zstd = { version = "0.13.1", optional = true }
 zstd-safe = { version = "7.2.1", optional = true }
-rustc-hash = "2.0.0"
 document-features = { version = "0.2.10", optional = true }
 xxhash-rust = { version = "0.8.12", features = ["xxh64"] }
+solana-nohash-hasher = "0.2.1"
 
 [features]
 default = ["xz", "gzip", "zstd"]

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -27,6 +27,7 @@ zstd = { version = "0.13.1", optional = true }
 zstd-safe = { version = "7.2.1", optional = true }
 rustc-hash = "2.0.0"
 document-features = { version = "0.2.10", optional = true }
+xxhash-rust = { version = "0.8.12", features = ["xxh64"] }
 
 [features]
 default = ["xz", "gzip", "zstd"]

--- a/backhand/src/data.rs
+++ b/backhand/src/data.rs
@@ -1,8 +1,11 @@
 //! File Data
 
+use std::collections::HashMap;
 use std::io::{Read, Seek, Write};
 
 use deku::prelude::*;
+use rustc_hash::FxHashMap;
+use xxhash_rust::xxh64::xxh64;
 
 use crate::compressor::CompressionAction;
 use crate::error::BackhandError;
@@ -100,6 +103,8 @@ pub(crate) struct DataWriter<'a> {
     kind: &'a dyn CompressionAction,
     block_size: u32,
     fs_compressor: FilesystemCompressor,
+    /// If some, cache of HashMap<file_len, HashMap<hash, (file_len, Added)>>
+    dup_cache: Option<HashMap<u64, HashMap<u64, (usize, Added)>>>,
     /// Un-written fragment_bytes
     pub(crate) fragment_bytes: Vec<u8>,
     pub(crate) fragment_table: Vec<Fragment>,
@@ -110,11 +115,13 @@ impl<'a> DataWriter<'a> {
         kind: &'a dyn CompressionAction,
         fs_compressor: FilesystemCompressor,
         block_size: u32,
+        no_duplicate_files: bool,
     ) -> Self {
         Self {
             kind,
             block_size,
             fs_compressor,
+            dup_cache: no_duplicate_files.then_some(HashMap::default()),
             fragment_bytes: Vec::with_capacity(block_size as usize),
             fragment_table: vec![],
         }
@@ -186,6 +193,9 @@ impl<'a> DataWriter<'a> {
     }
 
     /// Add to data writer, either a Data or Fragment
+    ///
+    /// If `self.dup_cache` is on, return alrady added `(usize, Added)` if duplicate
+    /// is found
     // TODO: support tail-end fragments (off by default in squashfs-tools/mksquashfs)
     pub(crate) fn add_bytes<W: WriteSeek>(
         &mut self,
@@ -197,6 +207,8 @@ impl<'a> DataWriter<'a> {
             file_len: 0,
             reader,
         };
+
+        // read entire chunk (file)
         let mut chunk = chunk_reader.read_chunk()?;
 
         // chunk size not exactly the size of the block
@@ -212,29 +224,58 @@ impl<'a> DataWriter<'a> {
             let block_offset = self.fragment_bytes.len() as u32;
             self.fragment_bytes.write_all(chunk)?;
 
-            Ok((chunk_reader.file_len, Added::Fragment { frag_index, block_offset }))
-        } else {
-            // Add to data bytes
-            let blocks_start = writer.stream_position()? as u32;
-            let mut block_sizes = vec![];
-            while !chunk.is_empty() {
-                let cb = self.kind.compress(chunk, self.fs_compressor, self.block_size)?;
-
-                // compression didn't reduce size
-                if cb.len() > chunk.len() {
-                    // store uncompressed
-                    block_sizes.push(DataSize::new_uncompressed(chunk.len() as u32));
-                    writer.write_all(chunk)?;
-                } else {
-                    // store compressed
-                    block_sizes.push(DataSize::new_compressed(cb.len() as u32));
-                    writer.write_all(&cb)?;
-                }
-                chunk = chunk_reader.read_chunk()?;
-            }
-
-            Ok((chunk_reader.file_len, Added::Data { blocks_start, block_sizes }))
+            return Ok((chunk_reader.file_len, Added::Fragment { frag_index, block_offset }));
         }
+
+        // Add to data bytes
+        let blocks_start = writer.stream_position()? as u32;
+        let mut block_sizes = vec![];
+
+        // If duplicate file checking is enabled, use the old data position as this file if it hashes the same
+        if let Some(dup_cache) = &self.dup_cache {
+            if let Some(c) = dup_cache.get(&(chunk.len() as u64)) {
+                let hash = xxh64(chunk, 0);
+                if let Some(res) = c.get(&hash) {
+                    trace!("duplicate file data found");
+                    return Ok(res.clone());
+                }
+            }
+        }
+
+        // Save information needed to add to duplicate_cache later
+        let chunk_len = chunk.len();
+        let hash = xxh64(chunk, 0);
+
+        while !chunk.is_empty() {
+            let cb = self.kind.compress(chunk, self.fs_compressor, self.block_size)?;
+
+            // compression didn't reduce size
+            if cb.len() > chunk.len() {
+                // store uncompressed
+                block_sizes.push(DataSize::new_uncompressed(chunk.len() as u32));
+                writer.write_all(chunk)?;
+            } else {
+                // store compressed
+                block_sizes.push(DataSize::new_compressed(cb.len() as u32));
+                writer.write_all(&cb)?;
+            }
+            chunk = chunk_reader.read_chunk()?;
+        }
+
+        // Add to duplicate information cache
+        let added = (chunk_reader.file_len, Added::Data { blocks_start, block_sizes });
+
+        // If duplicate files checking is enbaled, then add this to it's memory
+        if let Some(dup_cache) = &mut self.dup_cache {
+            if let Some(entry) = dup_cache.get_mut(&(chunk_len as u64)) {
+                entry.insert(hash, added.clone());
+            } else {
+                let mut hashmap = HashMap::new();
+                hashmap.insert(hash, added.clone());
+                dup_cache.insert(chunk_len as u64, hashmap);
+            }
+        }
+        Ok(added)
     }
 
     /// Compress the fragments that were under length, write to data, add to fragment table, clear
@@ -256,5 +297,48 @@ impl<'a> DataWriter<'a> {
         self.fragment_table.push(Fragment::new(start, size, 0));
         self.fragment_bytes.clear();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::{
+        compression::{Compressor, DefaultCompressor},
+        DEFAULT_BLOCK_SIZE,
+    };
+
+    #[test]
+    #[cfg(feature = "gzip")]
+    fn test_duplicate_check() {
+        let mut data_writer = DataWriter::new(
+            &DefaultCompressor,
+            FilesystemCompressor::new(Compressor::Gzip, None).unwrap(),
+            DEFAULT_BLOCK_SIZE,
+            true,
+        );
+        let bytes = [0xff_u8; DEFAULT_BLOCK_SIZE as usize * 2];
+        let mut writer = Cursor::new(vec![]);
+        let added_1 = data_writer.add_bytes(&bytes[..], &mut writer).unwrap();
+        let added_2 = data_writer.add_bytes(&bytes[..], &mut writer).unwrap();
+        assert_eq!(added_1, added_2);
+    }
+
+    #[test]
+    #[cfg(feature = "gzip")]
+    fn test_no_duplicate_check() {
+        let mut data_writer = DataWriter::new(
+            &DefaultCompressor,
+            FilesystemCompressor::new(Compressor::Gzip, None).unwrap(),
+            DEFAULT_BLOCK_SIZE,
+            false,
+        );
+        let bytes = [0xff_u8; DEFAULT_BLOCK_SIZE as usize * 2];
+        let mut writer = Cursor::new(vec![]);
+        let added_1 = data_writer.add_bytes(&bytes[..], &mut writer).unwrap();
+        let added_2 = data_writer.add_bytes(&bytes[..], &mut writer).unwrap();
+        assert_ne!(added_1, added_2);
     }
 }

--- a/backhand/src/lib.rs
+++ b/backhand/src/lib.rs
@@ -92,7 +92,8 @@ pub use crate::id::Id;
 pub use crate::inode::{BasicFile, Inode};
 pub use crate::reader::BufReadSeek;
 pub use crate::squashfs::{
-    Squashfs, SuperBlock, DEFAULT_BLOCK_SIZE, DEFAULT_PAD_LEN, MAX_BLOCK_SIZE, MIN_BLOCK_SIZE,
+    Flags, Squashfs, SuperBlock, DEFAULT_BLOCK_SIZE, DEFAULT_PAD_LEN, MAX_BLOCK_SIZE,
+    MIN_BLOCK_SIZE,
 };
 
 /// Support the wonderful world of vendor formats

--- a/backhand/src/reader.rs
+++ b/backhand/src/reader.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::io::{BufRead, Cursor, Read, Seek, SeekFrom, Write};
 
 use deku::prelude::*;
-use rustc_hash::FxHashMap;
+use solana_nohash_hasher::IntMap;
 use tracing::{error, trace};
 
 use crate::error::BackhandError;
@@ -86,7 +86,7 @@ pub trait SquashFsReader: BufReadSeek + Sized {
         &mut self,
         superblock: &SuperBlock,
         kind: &Kind,
-    ) -> Result<(Inode, FxHashMap<u32, Inode>), BackhandError> {
+    ) -> Result<(Inode, IntMap<u32, Inode>), BackhandError> {
         let (map, bytes) = self.uncompress_metadatas(
             superblock.inode_table,
             superblock,
@@ -94,7 +94,7 @@ pub trait SquashFsReader: BufReadSeek + Sized {
             kind,
         )?;
 
-        let mut inodes = FxHashMap::default();
+        let mut inodes = IntMap::default();
         inodes.try_reserve(superblock.inode_count as usize)?;
 
         let byte_len = bytes.len();
@@ -152,7 +152,7 @@ pub trait SquashFsReader: BufReadSeek + Sized {
         superblock: &SuperBlock,
         end_ptr: u64,
         kind: &Kind,
-    ) -> Result<(FxHashMap<u64, u64>, Vec<u8>), BackhandError> {
+    ) -> Result<(IntMap<u64, u64>, Vec<u8>), BackhandError> {
         self.seek(SeekFrom::Start(seek))?;
         let mut map = HashMap::default();
         let mut all_bytes = vec![];

--- a/backhand/src/squashfs.rs
+++ b/backhand/src/squashfs.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
 
 use deku::prelude::*;
-use rustc_hash::FxHashMap;
+use solana_nohash_hasher::IntMap;
 use tracing::{error, info, trace};
 
 use crate::compressor::{CompressionOptions, Compressor};
@@ -188,7 +188,7 @@ pub enum Flags {
 pub(crate) struct Cache {
     /// The first time a fragment bytes is read, those bytes are added to this map with the key
     /// representing the start position
-    pub(crate) fragment_cache: FxHashMap<u64, Vec<u8>>,
+    pub(crate) fragment_cache: IntMap<u64, Vec<u8>>,
 }
 
 /// Squashfs Image initial read information
@@ -200,11 +200,11 @@ pub struct Squashfs<'b> {
     /// Compression options that are used for the Compressor located after the Superblock
     pub compression_options: Option<CompressionOptions>,
     // Inode Cache `<InodeNumber, Inode>`
-    pub inodes: FxHashMap<u32, Inode>,
+    pub inodes: IntMap<u32, Inode>,
     /// Root Inode
     pub root_inode: Inode,
     /// Bytes containing Directory Table `(<OffsetFromImage, OffsetInData>, Data)`
-    pub dir_blocks: (FxHashMap<u64, u64>, Vec<u8>),
+    pub dir_blocks: (IntMap<u64, u64>, Vec<u8>),
     /// Fragments Lookup Table Cache
     pub fragments: Option<Vec<Fragment>>,
     /// Export Lookup Table Cache

--- a/backhand/src/squashfs.rs
+++ b/backhand/src/squashfs.rs
@@ -170,7 +170,7 @@ impl SuperBlock {
 #[rustfmt::skip]
 #[allow(dead_code)]
 #[derive(Debug, Copy, Clone)]
-pub(crate) enum Flags {
+pub enum Flags {
     InodesStoredUncompressed    = 0b0000_0000_0000_0001,
     DataBlockStoredUncompressed = 0b0000_0000_0000_0010,
     Unused                      = 0b0000_0000_0000_0100,


### PR DESCRIPTION
* Add cache to DataWriter, that if enabled will remember the file length and a hash of a previous file and use that instead of writing the matching file to disk.
* Add set_no_duplicate_files to FilesystemWriter to make this configurable.
* Make superblock Flags public

# TODO
- Maybe hash the first 32 bytes to do a quick comparison, before hashing the entire file
- cleanup code quality
-  Add test that adds a file that already exists, should be the same size? (might want to check that just_copy_it, works)
- Use https://github.com/paritytech/nohash-hasher (some other hashes I use could use this!)