### PR TITLE
backhand: Data duplication flag should be kept from reader

### DIFF
--- a/backhand-cli/src/bin/unsquashfs.rs
+++ b/backhand-cli/src/bin/unsquashfs.rs
@@ -336,8 +336,8 @@ fn stat(args: Args, mut file: BufReader<File>, kind: Kind) {
         println!("flag: fragments are always generated");
     }
 
-    if superblock.data_has_been_duplicated() {
-        println!("flag: data has been duplicated");
+    if superblock.data_has_been_deduplicated() {
+        println!("flag: data has been deduplicated");
     }
 
     if superblock.nfs_export_table_exists() {

--- a/backhand-test/tests/unsquashfs.rs
+++ b/backhand-test/tests/unsquashfs.rs
@@ -98,7 +98,7 @@ fn test_unsquashfs_cli() {
     export_table: 0x1308574,
 }
 Compression Options: None
-flag: data has been duplicated
+flag: data has been deduplicated
 flag: nfs export table exists
 "#,
     );

--- a/backhand/src/filesystem/reader.rs
+++ b/backhand/src/filesystem/reader.rs
@@ -87,10 +87,12 @@ pub struct FilesystemReader<'b> {
     pub fragments: Option<Vec<Fragment>>,
     /// All files and directories in filesystem
     pub root: Nodes<SquashfsFileReader>,
-    // File reader
+    /// File reader
     pub(crate) reader: Mutex<Box<dyn BufReadSeek + 'b>>,
-    // Cache used in the decompression
+    /// Cache used in the decompression
     pub(crate) cache: RwLock<Cache>,
+    /// Superblock Flag to remove duplicate flags
+    pub(crate) no_duplicate_files: bool,
 }
 
 impl<'b> FilesystemReader<'b> {

--- a/backhand/src/filesystem/writer.rs
+++ b/backhand/src/filesystem/writer.rs
@@ -78,6 +78,7 @@ pub struct FilesystemWriter<'a, 'b, 'c> {
     /// The log2 of the block size. If the two fields do not agree, the archive is considered corrupted.
     pub(crate) block_log: u16,
     pub(crate) pad_len: u32,
+    /// Superblock Flag to remove duplicate flags
     pub(crate) no_duplicate_files: bool,
 }
 
@@ -235,7 +236,7 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
             id_table: reader.id_table.clone(),
             root: Nodes { nodes: root },
             pad_len: DEFAULT_PAD_LEN,
-            no_duplicate_files: true,
+            no_duplicate_files: reader.no_duplicate_files,
         })
     }
 

--- a/backhand/src/squashfs.rs
+++ b/backhand/src/squashfs.rs
@@ -116,7 +116,7 @@ impl SuperBlock {
     }
 
     /// flag value
-    pub fn data_has_been_duplicated(&self) -> bool {
+    pub fn data_has_been_deduplicated(&self) -> bool {
         self.flags & Flags::DataHasBeenDeduplicated as u16 != 0
     }
 
@@ -429,7 +429,7 @@ impl<'b> Squashfs<'b> {
             info!("flag: fragments are always generated");
         }
 
-        if superblock.data_has_been_duplicated() {
+        if superblock.data_has_been_deduplicated() {
             info!("flag: data has been duplicated");
         }
 
@@ -646,6 +646,7 @@ impl<'b> Squashfs<'b> {
             root,
             reader: Mutex::new(Box::new(self.file)),
             cache: RwLock::new(Cache::default()),
+            no_duplicate_files: self.superblock.data_has_been_deduplicated(),
         };
         Ok(filesystem)
     }


### PR DESCRIPTION
* When using binaries such as add, or mutate the deduplicatin setting should be used that was read from the reader if we can