### PR TITLE
Remove check for ExtendedDirectory index count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `backhand`
+- Remove incorrect check for `ExtendedDirectory` index count ([#691](https://github.com/wcampbell0x2a/backhand/pull/691))
 
 ## [v0.19.0] - 2024-11-12
 ### `backhand`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### `backhand`
 - Remove incorrect check for `ExtendedDirectory` index count ([#691](https://github.com/wcampbell0x2a/backhand/pull/691))
+- Correctly support `ExtendedFile` ([#691](https://github.com/wcampbell0x2a/backhand/pull/691))
 
 ## [v0.19.0] - 2024-11-12
 ### `backhand`

--- a/backhand-cli/src/bin/unsquashfs.rs
+++ b/backhand-cli/src/bin/unsquashfs.rs
@@ -468,8 +468,8 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
 
                 // write to file
                 let fd = File::create(&filepath).unwrap();
-                let mut writer = BufWriter::with_capacity(file.basic.file_size as usize, &fd);
-                let file = filesystem.file(&file.basic);
+                let mut writer = BufWriter::with_capacity(file.file_len(), &fd);
+                let file = filesystem.file(file);
                 let mut reader = file.reader();
 
                 match io::copy(&mut reader, &mut writer) {

--- a/backhand-test/tests/non_standard.rs
+++ b/backhand-test/tests/non_standard.rs
@@ -30,12 +30,9 @@ fn full_test(
     {
         let file = BufReader::new(File::open(og_path).unwrap());
         info!("calling from_reader");
-        let og_filesystem = FilesystemReader::from_reader_with_offset_and_kind(
-            file,
-            offset,
-            Kind::from_kind(&kind),
-        )
-        .unwrap();
+        let og_filesystem =
+            FilesystemReader::from_reader_with_offset_and_kind(file, offset, Kind::from_kind(kind))
+                .unwrap();
         let mut new_filesystem = FilesystemWriter::from_fs_reader(&og_filesystem).unwrap();
         if let Some(pad) = pad {
             new_filesystem.set_kib_padding(pad);
@@ -57,7 +54,7 @@ fn full_test(
         let _new_filesystem = FilesystemReader::from_reader_with_offset_and_kind(
             created_file,
             offset,
-            Kind::from_kind(&kind),
+            Kind::from_kind(kind),
         )
         .unwrap();
     }
@@ -140,7 +137,7 @@ fn test_custom_compressor() {
             if let Compressor::Gzip = compressor {
                 out.resize(out.capacity(), 0);
                 let mut decompressor = libdeflater::Decompressor::new();
-                let amt = decompressor.zlib_decompress(&bytes, out).unwrap();
+                let amt = decompressor.zlib_decompress(bytes, out).unwrap();
                 out.truncate(amt);
             } else {
                 unimplemented!();

--- a/backhand/src/data.rs
+++ b/backhand/src/data.rs
@@ -137,7 +137,7 @@ impl<'a> DataWriter<'a> {
         mut writer: W,
     ) -> Result<(usize, Added), BackhandError> {
         //just clone it, because block sizes where never modified, just copy it
-        let mut block_sizes = reader.file.basic.block_sizes.clone();
+        let mut block_sizes = reader.file.file.block_sizes().to_vec();
         let mut read_buf = vec![];
         let mut decompress_buf = vec![];
 
@@ -190,7 +190,7 @@ impl<'a> DataWriter<'a> {
                 writer.write_all(&read_buf)?;
             }
         }
-        let file_size = reader.file.basic.file_size as usize;
+        let file_size = reader.file.file.file_len();
         Ok((file_size, Added::Data { blocks_start, block_sizes }))
     }
 

--- a/backhand/src/filesystem/writer.rs
+++ b/backhand/src/filesystem/writer.rs
@@ -217,7 +217,7 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
             .map(|node| {
                 let inner = match &node.inner {
                     InnerNode::File(file) => {
-                        let reader = reader.file(&file.basic);
+                        let reader = reader.file(file);
                         InnerNode::File(SquashfsFileWriter::SquashfsFile(reader))
                     }
                     InnerNode::Symlink(x) => InnerNode::Symlink(x.clone()),

--- a/backhand/src/inode.rs
+++ b/backhand/src/inode.rs
@@ -158,7 +158,6 @@ pub struct ExtendedDirectory {
     pub file_size: u32,
     pub block_index: u32,
     pub parent_inode: u32,
-    #[deku(assert = "*index_count < 256")]
     pub index_count: u16,
     pub block_offset: u16,
     pub xattr_index: u32,

--- a/backhand/src/inode.rs
+++ b/backhand/src/inode.rs
@@ -180,18 +180,6 @@ pub struct BasicFile {
     pub block_sizes: Vec<DataSize>,
 }
 
-impl From<&ExtendedFile> for BasicFile {
-    fn from(ex_file: &ExtendedFile) -> Self {
-        Self {
-            blocks_start: ex_file.blocks_start as u32,
-            frag_index: ex_file.frag_index,
-            block_offset: ex_file.block_offset,
-            file_size: ex_file.file_size as u32,
-            block_sizes: ex_file.block_sizes.clone(),
-        }
-    }
-}
-
 #[derive(Debug, DekuRead, DekuWrite, Clone, PartialEq, Eq)]
 #[deku(
     endian = "endian",

--- a/backhand/src/squashfs.rs
+++ b/backhand/src/squashfs.rs
@@ -544,17 +544,20 @@ impl<'b> Squashfs<'b> {
                         }
                         // BasicFile
                         InodeId::BasicFile => {
-                            trace!("before_file: {:#02x?}", entry);
-                            let basic = match &found_inode.inner {
-                                InodeInner::BasicFile(file) => file.clone(),
-                                InodeInner::ExtendedFile(file) => file.into(),
+                            let inner = match &found_inode.inner {
+                                InodeInner::BasicFile(file) => {
+                                    SquashfsFileReader::Basic(file.clone())
+                                }
+                                InodeInner::ExtendedFile(file) => {
+                                    SquashfsFileReader::Extended(file.clone())
+                                }
                                 _ => {
                                     return Err(BackhandError::UnexpectedInode(
                                         found_inode.inner.clone(),
                                     ))
                                 }
                             };
-                            InnerNode::File(SquashfsFileReader { basic })
+                            InnerNode::File(inner)
                         }
                         // Basic Symlink
                         InodeId::BasicSymlink => {


### PR DESCRIPTION
* This "check" was incorrect, and is over limiting the amount of dirs that _could_ be read. This was added to prevent over-allocing, but is now removed since it's incorrect.

Closes #690