### PR TITLE
Add lz4 compression and decompression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "libdeflater",
  "libz-ng-sys",
  "libz-sys",
+ "lz4_flex",
  "rust-lzo",
  "solana-nohash-hasher",
  "tempfile",
@@ -1110,6 +1111,12 @@ checksum = "3d6ea2a48c204030ee31a7d7fc72c93294c92fe87ecb1789881c9543516e1a0d"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 
 [[package]]
 name = "lzma-sys"

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -32,9 +32,10 @@ solana-nohash-hasher = "0.2.1"
 libz-sys = { version = "1.1.20", features = ["zlib-ng-no-cmake-experimental-community-maintained"], default-features = false }
 # Temporary workaround for https://github.com/rust-lang/libz-sys/issues/225
 libz-ng-sys = { version = "<1.1.20", optional = true }
+lz4_flex = { version = "0.11.3", optional = true, default-features = false }
 
 [features]
-default = ["xz", "gzip", "zstd"]
+default = ["xz", "gzip", "zstd", "lz4"]
 ## Enables xz compression inside library and binaries
 xz = ["dep:xz2"]
 ## Enables xz compression and forces static build inside library and binaries
@@ -47,6 +48,8 @@ gzip-zlib-ng = ["any-flate2", "any-gzip", "dep:flate2", "flate2?/zlib-ng"]
 lzo = ["dep:rust-lzo"]
 ## Enables zstd compression inside library and binaries
 zstd = ["dep:zstd", "dep:zstd-safe"]
+## Enables Lz4 compression
+lz4 = ["dep:lz4_flex"]
 ## Internal only
 any-gzip = []
 ## Internal only


### PR DESCRIPTION
I needed this myself to read a file in an LZ4-compressed squashfs. Should fix #9 

I haven't tested compression, but I suspect that's all there is to it.

Happy to make modifications!