### PR TITLE
Update flate2 with zlib-rs as default

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@08d473f7b2bf2e092f4c5bd3812b23ed7253f2c9 # cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       # generate release builds of the testable binaries
       # this is meant to actually run the binary, so this will fail but the binary will be built

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
           - --no-default-features --features gzip
           - --no-default-features --features gzip,xz
           - --no-default-features --features xz-static
-          - --no-default-features --features gzip-zlib-ng
           # default features
           -
 
@@ -112,7 +111,6 @@ jobs:
           - --no-default-features --features gzip
           - --no-default-features --features gzip,xz
           - --no-default-features --features xz-static
-          - --no-default-features --features gzip-zlib-ng
           # default features
           -
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,12 +664,11 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "libz-rs-sys",
  "miniz_oxide",
 ]
@@ -1064,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e19106f1b2c93f1fa6cdeec2e56facbf2e403559c1e1c0ddcc6d46e979cdf"
+checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
 dependencies = [
  "zlib-rs",
 ]
@@ -1144,9 +1143,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1572,12 +1571,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"
@@ -2410,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aada01553a9312bad4b9569035a1f12b05e5ec9770a1a4b323757356928944f8"
+checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ dependencies = [
  "xz2",
  "zstd",
  "zstd-safe",
- "zune-inflate",
 ]
 
 [[package]]
@@ -2441,13 +2440,4 @@ checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
 ]

--- a/backhand-cli/Cargo.toml
+++ b/backhand-cli/Cargo.toml
@@ -41,7 +41,6 @@ xz-static = ["xz", "backhand/xz-static"]
 ## Enables gzip compression inside library and binaries
 any-gzip = []
 gzip = ["any-gzip", "backhand/gzip"]
-gzip-zlib-ng = ["any-gzip", "backhand/gzip-zlib-ng"]
 ## This library is licensed GPL and thus disabled by default
 lzo = ["backhand/lzo"]
 ## Enables zstd compression inside library and binaries

--- a/backhand-test/Cargo.toml
+++ b/backhand-test/Cargo.toml
@@ -29,7 +29,6 @@ xz = ["backhand/xz"]
 xz-static = ["backhand/xz-static"]
 any-gzip = []
 gzip = ["any-gzip", "backhand/gzip"]
-gzip-zlib-ng = ["any-gzip", "backhand/gzip-zlib-ng"]
 # this library is licensed GPL and thus disabled by default
 lzo = ["backhand/lzo"]
 zstd = ["backhand/zstd"]

--- a/backhand-test/tests/test.rs
+++ b/backhand-test/tests/test.rs
@@ -127,7 +127,7 @@ fn full_test_inner(
 
 /// mksquashfs ./target/release/squashfs-deku out.squashfs -comp gzip -Xcompression-level 2 -always-use-fragments
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_00() {
     const FILE_NAME: &str = "out.squashfs";
     let asset_defs = [TestAssetDef {
@@ -146,7 +146,7 @@ fn test_00() {
 
 /// mksquashfs ./target/release/squashfs-deku out.squashfs -comp gzip -Xcompression-level 2
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_01() {
     const FILE_NAME: &str = "out.squashfs";
     let asset_defs = [TestAssetDef {
@@ -218,7 +218,7 @@ fn test_05() {
 
 /// mksquashfs ./target/release/squashfs-deku out.squashfs -comp gzip -always-use-fragments
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_06() {
     const FILE_NAME: &str = "out.squashfs";
     let asset_defs = [TestAssetDef {
@@ -236,7 +236,7 @@ fn test_06() {
 
 /// mksquashfs ./target/release/squashfs-deku out.squashfs -comp gzip
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_07() {
     const FILE_NAME: &str = "out.squashfs";
     let asset_defs = [TestAssetDef {
@@ -326,7 +326,7 @@ fn test_openwrt_netgear_ex6100v2() {
 }
 
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_appimage_plexamp() {
     const FILE_NAME: &str = "Plexamp-4.6.1.AppImage";
     let asset_defs = [TestAssetDef {
@@ -344,7 +344,7 @@ fn test_appimage_plexamp() {
 }
 
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_appimage_firefox() {
     const FILE_NAME: &str = "firefox-108.0.r20221215175817-x86_64.AppImage";
     let asset_defs = [TestAssetDef {
@@ -431,7 +431,7 @@ fn test_slow_archlinux_iso_rootfs() {
 }
 
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_many_files() {
     const FILE_NAME: &str = "many_files.squashfs";
     let asset_defs = [TestAssetDef {
@@ -449,7 +449,7 @@ fn test_many_files() {
 }
 
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_many_dirs() {
     const FILE_NAME: &str = "many_dirs.squashfs";
     let asset_defs = [TestAssetDef {
@@ -467,7 +467,7 @@ fn test_many_dirs() {
 }
 
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_few_dirs_many_files() {
     const FILE_NAME: &str = "few_dirs_many_files.squashfs";
     let asset_defs = [TestAssetDef {
@@ -486,7 +486,7 @@ fn test_few_dirs_many_files() {
 }
 
 #[test]
-#[cfg(any(feature = "gzip", feature = "gzip-zune-inflate"))]
+#[cfg(any(feature = "gzip"))]
 fn test_socket_fifo() {
     const FILE_NAME: &str = "squashfs_v4.specfile.bin";
     let asset_defs = [TestAssetDef {

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -20,7 +20,6 @@ deku = { version = "0.18.1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.40" }
 thiserror = "2.0.1"
 flate2 = { version = "1.0.34", optional = true }
-zune-inflate = { version = "0.2.54", optional = true, default-features = false, features = ["zlib"] }
 xz2 = { version = "0.1.7", optional = true }
 rust-lzo = { version = "0.6.2", optional = true }
 zstd = { version = "0.13.2", optional = true }

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 deku = { version = "0.18.1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.40" }
 thiserror = "2.0.1"
-flate2 = { version = "1.0.34", optional = true }
+flate2 = { version = "1.1.0", optional = true, default-features = false, features = ["zlib-rs"] }
 xz2 = { version = "0.1.7", optional = true }
 rust-lzo = { version = "0.6.2", optional = true }
 zstd = { version = "0.13.2", optional = true }
@@ -39,9 +39,7 @@ xz = ["dep:xz2"]
 ## Enables xz compression and forces static build inside library and binaries
 xz-static = ["dep:xz2", "xz2?/static"]
 ## Enables gzip compression inside library and binaries using flate2 library with zlib-rs
-gzip = ["any-flate2", "any-gzip", "dep:flate2", "flate2?/zlib-rs"]
-## Enables gzip compression inside library and binaries using flate2 library with zlib-ng
-gzip-zlib-ng = ["any-flate2", "any-gzip", "dep:flate2", "flate2?/zlib-ng"]
+gzip = ["any-flate2", "any-gzip", "dep:flate2"]
 ## This library is licensed GPL and thus disabled by default
 lzo = ["dep:rust-lzo"]
 ## Enables zstd compression inside library and binaries


### PR DESCRIPTION
The usage of zune-inflate was already remove, this removes from Cargo.toml
and other references