### PR TITLE
Avoid misaligned pointer loads with Deku and id_type = u16

### DIFF
--- a/backhand/src/compressor.rs
+++ b/backhand/src/compressor.rs
@@ -23,6 +23,7 @@ use crate::SuperBlock;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, DekuRead, DekuWrite, Default)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 #[deku(id_type = "u16")]
+#[repr(u16)]
 #[rustfmt::skip]
 pub enum Compressor {
     None = 0,

--- a/backhand/src/inode.rs
+++ b/backhand/src/inode.rs
@@ -65,6 +65,7 @@ impl Inode {
 #[derive(Debug, DekuRead, DekuWrite, Clone, Copy, PartialEq, Eq)]
 #[deku(id_type = "u16")]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
+#[repr(u16)]
 #[rustfmt::skip]
 pub enum InodeId {
     BasicDirectory       = 1,


### PR DESCRIPTION
The underlying issue is https://github.com/sharksforarms/deku/issues/552. Adding `#[repr(u16)]` works around the problem.