### PR TITLE
Add mksquashfs-backhand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,15 +151,19 @@ name = "backhand-cli"
 version = "0.23.0"
 dependencies = [
  "backhand",
+ "bytesize",
  "clap",
  "clap-cargo",
  "clap_complete",
  "color-print",
  "console",
+ "dateparser",
+ "ignore",
  "indicatif",
  "jemallocator",
  "libc",
  "nix",
+ "pathdiff",
  "rayon",
  "tracing",
  "tracing-subscriber",
@@ -227,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
+name = "bytesize"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c434ae3cf0089ca203e9019ebe529c47ff45cefe8af7c85ecb734ef541822f"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +279,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -383,6 +421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +551,18 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dateparser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ef451feee09ae5ecd8a02e738bd9adee9266b8fa9b44e22d3ce968d8694238"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -728,6 +784,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +835,30 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -878,6 +971,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.9",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1215,6 +1324,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2082,6 +2197,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ codegen-units = 1
 lto = true
 strip = true
 overflow-checks = true
+
+[profile.perf]
+inherits = "release"
+debug = true

--- a/backhand-cli/Cargo.toml
+++ b/backhand-cli/Cargo.toml
@@ -24,6 +24,10 @@ backhand = { path = "../backhand", default-features = false, version = "0.23.0" 
 tracing = "0.1.40"
 color-print = "0.3.6"
 clap-cargo = "0.15.0"
+ignore = "0.4.23"
+bytesize = "2.1.0"
+dateparser = "0.2.1"
+pathdiff = "0.2.3"
 
 [lib]
 bench = false
@@ -62,4 +66,9 @@ bench = false
 [[bin]]
 name = "replace-backhand"
 path = "src/bin/replace.rs"
+bench = false
+
+[[bin]]
+name = "mksquashfs-backhand"
+path = "src/bin/mksquashfs.rs"
 bench = false

--- a/backhand-cli/src/bin/add.rs
+++ b/backhand-cli/src/bin/add.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use backhand::{FilesystemReader, FilesystemWriter, NodeHeader};
-use backhand_cli::after_help;
+use backhand_cli::after_help_unsquashfs;
 use clap::Parser;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
@@ -20,7 +20,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[command(author,
           version,
           name = "add-backhand",
-          after_help = after_help(false),
+          after_help = after_help_unsquashfs(false),
           max_term_width = 98,
           styles = clap_cargo::style::CLAP_STYLING,
 )]

--- a/backhand-cli/src/bin/mksquashfs.rs
+++ b/backhand-cli/src/bin/mksquashfs.rs
@@ -1,0 +1,403 @@
+use std::{
+    fs::{read_link, File, Metadata, OpenOptions},
+    io::{self, BufReader},
+    path::{Path, PathBuf},
+    process::ExitCode,
+    time::Duration,
+};
+
+use backhand::{
+    compression::{CompressionOptions, Compressor, Gzip, Lz4, Lzo, Xz, XzFilter, Zstd},
+    BackhandError, FilesystemCompressor, FilesystemReader, FilesystemWriter, NodeHeader,
+};
+use backhand_cli::{
+    after_help_common,
+    parse::{parse_window_size, parse_xz_dict_size, parse_xz_filter},
+};
+use clap::{error::ErrorKind, CommandFactory, Parser};
+use clap_complete::{generate, Shell};
+use console::Term;
+use dateparser::DateTimeUtc;
+use indicatif::{ProgressBar, ProgressStyle};
+
+use backhand_cli::parse::{parse_block_size, parse_compressor, parse_gid, parse_octal, parse_uid};
+use pathdiff::diff_paths;
+
+/// Command-line tool to create squashfs filesystems from a list of input files.
+#[derive(Parser)]
+#[command(author,
+          version,
+          name = "mksquashfs-backhand",
+          after_help = after_help_common(true),
+          max_term_width = 98,
+          styles = clap_cargo::style::CLAP_STYLING,
+)]
+struct Args {
+    #[arg(required_unless_present = "completions")]
+    filesystem: Option<PathBuf>,
+    sources: Vec<PathBuf>,
+    /// Emit shell completion scripts
+    #[arg(long)]
+    completions: Option<Shell>,
+
+    /// Silence all progress bar and RUST_LOG output
+    #[arg(long)]
+    quiet: bool,
+
+    /// Size of compressed data blocks. Supports an optional K or M suffix
+    #[arg(short, default_value = "128K", value_parser = parse_block_size)]
+    block_size: u32,
+
+    /// Compression type used to build squashfs. Compressors available are gzip, lzo, lz4, xz and zstd
+    #[arg(long = "comp", default_value = "xz", value_parser = parse_compressor)]
+    comp: Compressor,
+
+    /// Filesystem creation timestamp.
+    /// Can be a Unix timestamp or any time format supported by the dateparser crate
+    #[arg(long = "mkfs-time")]
+    mkfs_time: Option<DateTimeUtc>,
+
+    /// Do not check for duplicate files
+    #[arg(long = "no-duplicates")]
+    no_duplicates: bool,
+
+    /// Pad the filesystem to a multiple of [PADDING] KiB
+    #[arg(long = "padding", default_value_t = 4)]
+    padding: u32,
+
+    /// Make all files in the squashfs owned by the root user
+    #[arg(long = "all-root")]
+    all_root: bool,
+
+    /// Set the root directory permissions to the given octal mode
+    #[arg(long = "root-dir-mode", value_parser = parse_octal)]
+    root_dir_mode: Option<u16>,
+
+    /// Set the root directory uid. Can be an integer uid, or a username when run on a Unix host
+    #[arg(long = "root-dir-uid", value_parser = parse_uid)]
+    root_dir_uid: Option<u32>,
+
+    /// Set the root directory gid. Can be an integer gid, or a group name when run on a Unix host
+    #[arg(long = "root-dir-gid", value_parser = parse_gid)]
+    root_dir_gid: Option<u32>,
+
+    /// Maximum depth to which source paths will be searched for files. By default, search depth will not be limited
+    #[arg(long = "max-depth")]
+    max_depth: Option<usize>,
+
+    /// Set the uids of all entries to this value. Can be an integer uid, or a username when run on a Unix host
+    #[arg(long = "force-uid", value_parser = parse_uid)]
+    force_uid: Option<u32>,
+
+    /// Set the gids of all entries to this value. Can be an integer gid, or a group name when run on a Unix host
+    #[arg(long = "force-gid", value_parser = parse_gid)]
+    force_gid: Option<u32>,
+
+    /// Append to the existing squashfs at [FILESYSTEM] instead of creating a new one
+    #[arg(long = "append")]
+    append: bool,
+
+    /// Compression level to use when building the squashfs. Range varies by compressor:
+    ///
+    /// gzip: [1, 9]
+    ///
+    /// lzo: [1, 9]
+    ///
+    /// zstd: [1, 22]
+    #[arg(long = "Xcompression-level")]
+    compression_level: Option<u32>,
+
+    /// Window size to use for gzip compression. Must be in the range [1, 15]
+    #[arg(long = "Xgzip-window-size", default_value_t = 15, requires_if("gzip", "comp"), value_parser = parse_window_size)]
+    gzip_window_size: u16,
+
+    /// Branch/call/jump filters to try for xz compression before taking the best one
+    #[arg(long = "Xxz-bcj", value_parser = parse_xz_filter, requires_if("xz", "comp"))]
+    xz_bcj: Option<XzFilter>,
+
+    /// Dictionary size to use for xz compression, which defaults to the same as the block size.
+    ///
+    /// Dictionary size can be a raw value or have an optional K/M suffix.
+    /// It must be in the range [8K, block size] and be either a power of 2 or a power of 2 multiplied by 3
+    #[arg(long = "Xxz-dict-size", value_parser = parse_xz_dict_size, requires_if("xz", "comp"))]
+    xz_dict_size: Option<u32>,
+
+    /// When set, source paths will be stored in their entirety, rather than only keeping the relative portion
+    #[arg(long = "no-strip")]
+    no_strip: bool,
+}
+
+/// Print the given message in red, bold text and exit the program
+macro_rules! err_fatal {
+    ($input:expr, $pb:expr) => {{
+        let line = format!("{:>14}", ::backhand_cli::RED_BOLD.apply_to($input));
+        $pb.finish_with_message(line);
+        $pb.tick();
+        return ::std::process::ExitCode::FAILURE;
+    }};
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+    // Create progress bar and set a style similar to that of squashfs-tools' mksquashfs
+    let pb = ProgressBar::new(0);
+    if !args.quiet {
+        tracing_subscriber::fmt::init();
+        pb.set_style(
+            ProgressStyle::with_template(
+                // note that bar size is fixed unlike cargo which is dynamic
+                // and also the truncation in cargo uses trailers (`...`)
+                if Term::stdout().size().1 > 80 {
+                    "{prefix:>16.cyan.bold} [{bar:57}] {pos}/{len} {wide_msg}"
+                } else {
+                    "{prefix:>16.cyan.bold} [{bar:57}] {pos}/{len}"
+                },
+            )
+            .unwrap()
+            .progress_chars("=> "),
+        );
+    }
+
+    // Generate shell completions
+    if let Some(completions) = args.completions {
+        let mut cmd = Args::command();
+        let name = cmd.get_name().to_string();
+        generate(completions, &mut cmd, name, &mut io::stdout());
+        return ExitCode::SUCCESS;
+    }
+
+    // If appending to an existing filesystem, open a reader
+    let reader = if args.append {
+        let file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .open(args.filesystem.as_ref().unwrap())
+            .map_err(BackhandError::StdIo);
+        let filesystem_reader =
+            file.and_then(|file| FilesystemReader::from_reader(BufReader::new(file)));
+        match filesystem_reader {
+            Ok(reader) => Some(reader),
+            Err(e) => err_fatal!(format!("Could not read source filesystem: {e:?}"), pb),
+        }
+    } else {
+        None
+    };
+
+    // Either open the reader to which we are appending or create a new writer
+    let mut writer = match reader.as_ref().map(FilesystemWriter::from_fs_reader) {
+        Some(fs_writer) => match fs_writer {
+            Ok(writer) => writer,
+            Err(e) => {
+                err_fatal!(format!("Could not create writer from existing filesystem: {e:?}"), pb)
+            }
+        },
+        None => Default::default(),
+    };
+
+    // Validate compression level now, since the logic is more complex than what clap derives can handle
+    match (&args.compression_level, &args.comp) {
+        (None, _) => {}
+        (Some(compression_level), Compressor::Gzip) => {
+            if *compression_level < 1 || *compression_level > 9 {
+                let mut cmd = Args::command();
+                cmd.error(
+                    ErrorKind::InvalidValue,
+                    "Compression level for gzip must be in the range [1, 9].",
+                )
+                .exit();
+            }
+        }
+        (Some(compression_level), Compressor::Lzo) => {
+            if *compression_level < 1 || *compression_level > 9 {
+                let mut cmd = Args::command();
+                cmd.error(
+                    ErrorKind::InvalidValue,
+                    "Compression level for lzo must be in the range [1, 9].",
+                )
+                .exit();
+            }
+        }
+        (Some(compression_level), Compressor::Zstd) => {
+            if *compression_level < 1 || *compression_level > 22 {
+                let mut cmd = Args::command();
+                cmd.error(
+                    ErrorKind::InvalidValue,
+                    "Compression level for zstd must be in the range [1, 22].",
+                )
+                .exit();
+            }
+        }
+        (Some(_), comp) => {
+            let mut cmd = Args::command();
+            cmd.error(
+                ErrorKind::InvalidValue,
+                format!("A compression level cannot be specified for compressor {comp:?}"),
+            )
+            .exit();
+        }
+    }
+
+    // Everything here set to a zero is unimplemented in the backhand library
+    let compression_options = match args.comp {
+        Compressor::None => unreachable!(),
+        Compressor::Gzip => {
+            let gzip_options = Gzip {
+                window_size: args.gzip_window_size,
+                strategies: 0,
+                compression_level: args.compression_level.unwrap_or(9),
+            };
+            CompressionOptions::Gzip(gzip_options)
+        }
+        Compressor::Lzma => unreachable!(),
+        Compressor::Lzo => CompressionOptions::Lzo(Lzo { algorithm: 0, compression_level: 0 }),
+        Compressor::Xz => {
+            let xz_options = Xz {
+                filters: args.xz_bcj.unwrap_or_default(),
+                dictionary_size: args.xz_dict_size.unwrap_or(args.block_size),
+                bit_opts: None,
+                fb: None,
+            };
+            CompressionOptions::Xz(xz_options)
+        }
+        Compressor::Lz4 => CompressionOptions::Lz4(Lz4 { version: 0, flags: 0 }),
+        Compressor::Zstd => {
+            let zstd_options = Zstd { compression_level: args.compression_level.unwrap_or(15) };
+            CompressionOptions::Zstd(zstd_options)
+        }
+    };
+    // Apply command-line options to the filesystem writer
+    writer.set_compressor(FilesystemCompressor::new(args.comp, Some(compression_options)).unwrap());
+    writer.set_block_size(args.block_size);
+    if let Some(ref mkfs_time) = args.mkfs_time {
+        writer.set_time(mkfs_time.0.timestamp() as u32);
+    }
+    writer.set_no_duplicate_files(args.no_duplicates);
+    writer.set_kib_padding(args.padding);
+    if args.all_root {
+        writer.set_only_root_id();
+    }
+    if let Some(mode) = args.root_dir_mode {
+        writer.set_root_mode(mode);
+    }
+    if let Some(uid) = args.root_dir_uid {
+        writer.set_root_uid(uid);
+    } else {
+        writer.set_root_mode(0o555);
+    }
+    if let Some(gid) = args.root_dir_gid {
+        writer.set_root_gid(gid);
+    }
+
+    // Add files one at a time to the squashfs
+    let file_count = match push_entries(&mut writer, &args) {
+        Ok(count) => count,
+        Err(e) => err_fatal!(format!("Could not add entries to squashfs: {e}"), pb),
+    };
+    if !args.quiet {
+        pb.set_length(file_count);
+        pb.enable_steady_tick(Duration::from_millis(120));
+    }
+    let mut output = File::create(args.filesystem.unwrap()).unwrap();
+    writer.write_callback(&mut output, Some(|| pb.inc(1))).unwrap();
+
+    pb.finish_with_message("Done!");
+    ExitCode::SUCCESS
+}
+
+/// Add entries to a squashfs writer based on a command-line configuration.
+#[tracing::instrument(skip(args))]
+fn push_entries(writer: &mut FilesystemWriter, args: &Args) -> Result<u64, BackhandError> {
+    let mut file_count = 0;
+    for source in &args.sources {
+        // Recursively walk through the source path and add all children
+        let entries = ignore::WalkBuilder::new(source)
+            .standard_filters(false)
+            .max_depth(args.max_depth)
+            .build();
+
+        for entry in entries {
+            let dir_entry = entry.map_err(|_| BackhandError::FileNotFound)?;
+            let meta = dir_entry.metadata().map_err(|_| BackhandError::FileNotFound)?;
+            // Convert paths to relative paths unless no_strip is specified
+            let pushed_path = if args.no_strip {
+                dir_entry.path().to_path_buf()
+            } else if source != dir_entry.path() {
+                Path::new("/").join(diff_paths(dir_entry.path(), source).unwrap())
+            } else if dir_entry.metadata().as_ref().is_ok_and(Metadata::is_file) {
+                Path::new("/").join(dir_entry.file_name())
+            } else {
+                continue;
+            };
+
+            #[cfg(target_family = "unix")]
+            let node = {
+                use std::os::unix::fs::MetadataExt;
+                let mode = (meta.mode() & 0xfff) as u16;
+                let uid = args.force_uid.unwrap_or(meta.uid());
+                let gid = args.force_gid.unwrap_or(meta.gid());
+                let mtime = meta.mtime() as u32;
+                NodeHeader::new(mode, uid, gid, mtime)
+            };
+            #[cfg(not(target_family = "unix"))]
+            let node = NodeHeader::default();
+
+            // Add a new inode to the squashfs based on the file type of this entry
+            let ftype = meta.file_type();
+            if ftype.is_file() {
+                let file = File::open(dir_entry.path()).map_err(BackhandError::StdIo)?;
+                writer.push_file(file, &pushed_path, node)?;
+                file_count += 1;
+            } else if ftype.is_dir() {
+                writer.push_dir_all(&pushed_path, node)?;
+            } else if ftype.is_symlink() {
+                writer.push_symlink(
+                    read_link(dir_entry.path()).map_err(BackhandError::StdIo)?,
+                    &pushed_path,
+                    node,
+                )?;
+            }
+            #[cfg(target_family = "unix")]
+            {
+                use libc::stat;
+                use std::os::unix::fs::FileTypeExt;
+                use std::{
+                    alloc::{alloc, Layout},
+                    ffi::CString,
+                };
+
+                if ftype.is_block_device() {
+                    // Retrieve device number
+                    let statbuf = unsafe { alloc(Layout::new::<stat>()) } as *mut stat;
+                    unsafe {
+                        stat(
+                            CString::new(dir_entry.path().as_os_str().as_encoded_bytes())
+                                .unwrap()
+                                .as_ptr(),
+                            statbuf,
+                        )
+                    };
+                    let device_id = unsafe { (*statbuf).st_rdev } as u32;
+                    writer.push_block_device(device_id, &pushed_path, node)?;
+                } else if ftype.is_char_device() {
+                    // Retrieve device number
+                    let statbuf = unsafe { alloc(Layout::new::<stat>()) } as *mut stat;
+                    unsafe {
+                        stat(
+                            CString::new(dir_entry.path().as_os_str().as_encoded_bytes())
+                                .unwrap()
+                                .as_ptr(),
+                            statbuf,
+                        )
+                    };
+                    let device_id = unsafe { (*statbuf).st_rdev } as u32;
+                    writer.push_char_device(device_id, &pushed_path, node)?;
+                } else if ftype.is_fifo() {
+                    writer.push_fifo(&pushed_path, node)?;
+                } else if ftype.is_socket() {
+                    writer.push_socket(&pushed_path, node)?;
+                }
+            }
+        }
+    }
+    Ok(file_count)
+}

--- a/backhand-cli/src/bin/mksquashfs_implemented.md
+++ b/backhand-cli/src/bin/mksquashfs_implemented.md
@@ -1,0 +1,116 @@
+# Unimplemented mksquashfs arguments:
+
+## Filesystem compression options:
+
+- -noI
+- -noId
+- -noD
+- -noF
+- -noX
+- -no-compression
+
+## Filesystem build options:
+
+- -tar
+- -cpiostyle
+- -cpiostyle0
+- -reproducible
+- -all-time
+- -root-time
+- -no-exports
+- -exports
+- -no-sparse
+- -tailends
+- -no-fragments
+- -no-hardlinks
+- -keep-as-directory
+
+## Filesystem filter options:
+
+- -sort
+- -ef
+- -wildcards
+- -regex
+- -one-file-system
+- -one-file-system-x
+
+## Filesystem xattrs options:
+
+- -xattrs-exclude
+- -xattrs-include
+- -xattrs-add
+
+## Runtime options:
+
+- -exit-on-error
+- -info
+- -percentage
+- -throttle
+- -limit
+- -processors
+- -mem
+- -mem-percent
+
+## Filesystem append options:
+
+- -root-becomes
+
+## Expert:
+
+- -offset
+
+## Tar file only options:
+
+- -default-mode
+- -default-uid
+- -default-gid
+- -ignore-zeros
+
+## Compression options:
+
+- gzip:
+  - -Xstrategy
+- lzo:
+  - -Xalgorithm
+  - -Xcompression-level
+- lz4:
+  - Xhc
+
+## Deliberately unimplemented:
+
+- -tarstyle
+- -reproducible
+- -not-reproducible
+- -no-tailends
+- -pseudo-override
+- -p
+- -pf
+- -no-xattrs
+- -xattrs
+- -nopad
+- -no-progress
+- -progress
+- -mem-default
+- -no-recovery
+- -recovery-path
+- -recover
+- -action
+- -log-action
+- -true-action
+- -false-action
+- -action-file
+- -log-action-file
+- -true-action-file
+- -false-action-file
+
+## Deliberately changed:
+
+- -nopad => --padding
+- -root-mode => --root-dir-mode
+- -root-uid => --root-dir-uid
+- -root-gid => --root-dir-gid
+- -noappend => -append
+- -Xwindow-size => --Xgzip-window-size
+- -Xbcj => --Xxz-bcj
+- -Xdict-size => --Xxz-dict-size without the ability to specify a percentage of block size
+- No lzma compression support

--- a/backhand-cli/src/bin/replace.rs
+++ b/backhand-cli/src/bin/replace.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use backhand::{FilesystemReader, FilesystemWriter};
-use backhand_cli::after_help;
+use backhand_cli::after_help_unsquashfs;
 use clap::Parser;
 use tracing::error;
 use tracing_subscriber::EnvFilter;
@@ -19,7 +19,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[command(author,
           version,
           name = "replace-backhand",
-          after_help = after_help(false),
+          after_help = after_help_unsquashfs(false),
           max_term_width = 98,
           styles = clap_cargo::style::CLAP_STYLING,
 )]

--- a/backhand-cli/src/bin/unsquashfs.rs
+++ b/backhand-cli/src/bin/unsquashfs.rs
@@ -12,7 +12,7 @@ use backhand::{
     BufReadSeek, FilesystemReader, InnerNode, Node, NodeHeader, Squashfs, SquashfsBlockDevice,
     SquashfsCharacterDevice, SquashfsDir, SquashfsFileReader, SquashfsSymlink, DEFAULT_BLOCK_SIZE,
 };
-use backhand_cli::after_help;
+use backhand_cli::{after_help_unsquashfs, BLUE_BOLD, RED_BOLD};
 use clap::builder::PossibleValuesParser;
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Shell};
@@ -55,26 +55,22 @@ fn find_offset(file: &mut BufReader<File>, kind: &Kind) -> Option<u64> {
 }
 
 pub fn extracted(pb: &ProgressBar, s: &str) {
-    let blue_bold: console::Style = console::Style::new().blue().bold();
-    let line = format!("{:>16} {}", blue_bold.apply_to("Extracted"), s,);
+    let line = format!("{:>16} {}", BLUE_BOLD.apply_to("Extracted"), s,);
     pb.println(line);
 }
 
 pub fn created(pb: &ProgressBar, s: &str) {
-    let blue_bold: console::Style = console::Style::new().blue().bold();
-    let line = format!("{:>16} {}", blue_bold.apply_to("Created"), s,);
+    let line = format!("{:>16} {}", BLUE_BOLD.apply_to("Created"), s,);
     pb.println(line);
 }
 
 pub fn exists(pb: &ProgressBar, s: &str) {
-    let red_bold: console::Style = console::Style::new().red().bold();
-    let line = format!("{:>16} {}", red_bold.apply_to("Exists"), s,);
+    let line = format!("{:>16} {}", RED_BOLD.apply_to("Exists"), s,);
     pb.println(line);
 }
 
 pub fn failed(pb: &ProgressBar, s: &str) {
-    let red_bold: console::Style = console::Style::new().red().bold();
-    let line = format!("{:>16} {}", red_bold.apply_to("Failed"), s,);
+    let line = format!("{:>16} {}", RED_BOLD.apply_to("Failed"), s,);
     pb.println(line);
 }
 
@@ -83,7 +79,7 @@ pub fn failed(pb: &ProgressBar, s: &str) {
 #[command(author,
           version,
           name = "unsquashfs-backhand",
-          after_help = after_help(true),
+          after_help = after_help_unsquashfs(true),
           max_term_width = 98,
           styles = clap_cargo::style::CLAP_STYLING,
 )]
@@ -177,26 +173,24 @@ fn main() -> ExitCode {
         File::open(args.filesystem.as_ref().unwrap()).unwrap(),
     );
 
-    let blue_bold: console::Style = console::Style::new().blue().bold();
-    let red_bold: console::Style = console::Style::new().red().bold();
     let pb = ProgressBar::new_spinner();
 
     if args.auto_offset {
         if !args.quiet {
             pb.enable_steady_tick(Duration::from_millis(120));
-            let line = format!("{:>14}", blue_bold.apply_to("Searching for magic"));
+            let line = format!("{:>14}", BLUE_BOLD.apply_to("Searching for magic"));
             pb.set_message(line);
         }
         if let Some(found_offset) = find_offset(&mut file, &kind) {
             if !args.quiet {
                 let line =
-                    format!("{:>14} 0x{:08x}", blue_bold.apply_to("Found magic"), found_offset,);
+                    format!("{:>14} 0x{:08x}", BLUE_BOLD.apply_to("Found magic"), found_offset,);
                 pb.finish_with_message(line);
             }
             args.offset = found_offset;
         } else {
             if !args.quiet {
-                let line = format!("{:>14}", red_bold.apply_to("Magic not found"),);
+                let line = format!("{:>14}", RED_BOLD.apply_to("Magic not found"),);
                 pb.finish_with_message(line);
             }
             return ExitCode::FAILURE;
@@ -211,7 +205,7 @@ fn main() -> ExitCode {
     let squashfs = match Squashfs::from_reader_with_offset_and_kind(file, args.offset, kind) {
         Ok(s) => s,
         Err(_e) => {
-            let line = format!("{:>14}", red_bold.apply_to(format!("Could not read image: {_e}")));
+            let line = format!("{:>14}", RED_BOLD.apply_to(format!("Could not read image: {_e}")));
             pb.finish_with_message(line);
             return ExitCode::FAILURE;
         }
@@ -227,12 +221,12 @@ fn main() -> ExitCode {
     let pb = ProgressBar::new_spinner();
     if !args.quiet {
         pb.enable_steady_tick(Duration::from_millis(120));
-        let line = format!("{:>14}", blue_bold.apply_to("Reading image"));
+        let line = format!("{:>14}", BLUE_BOLD.apply_to("Reading image"));
         pb.set_message(line);
     }
     let filesystem = squashfs.into_filesystem_reader().unwrap();
     if !args.quiet {
-        let line = format!("{:>14}", blue_bold.apply_to("Read image"));
+        let line = format!("{:>14}", BLUE_BOLD.apply_to("Read image"));
         pb.finish_with_message(line);
     }
 
@@ -250,7 +244,7 @@ fn main() -> ExitCode {
                 if !args.quiet {
                     let line = format!(
                         "{:>14}",
-                        red_bold.apply_to("Invalid --path-filter, path doesn't exist")
+                        RED_BOLD.apply_to("Invalid --path-filter, path doesn't exist")
                     );
                     pb.finish_with_message(line);
                 }

--- a/backhand-cli/src/lib.rs
+++ b/backhand-cli/src/lib.rs
@@ -1,5 +1,18 @@
 // Compiled for every binary, as this is not a workspace
+
+pub mod parse;
+
+use std::sync::LazyLock;
+
 use clap::builder::styling::*;
+
+#[doc(hidden)]
+pub static RED_BOLD: LazyLock<console::Style> =
+    LazyLock::new(|| console::Style::new().red().bold());
+#[doc(hidden)]
+pub static BLUE_BOLD: LazyLock<console::Style> =
+    LazyLock::new(|| console::Style::new().blue().bold());
+
 #[doc(hidden)]
 pub fn styles() -> clap::builder::Styles {
     Styles::styled()
@@ -13,7 +26,7 @@ pub fn styles() -> clap::builder::Styles {
 }
 
 #[doc(hidden)]
-pub fn after_help(rayon_env: bool) -> String {
+pub fn after_help_unsquashfs(rayon_env: bool) -> String {
     let mut s = String::new();
 
     let header = color_print::cstr!("<green, bold>Decompressors available:</>\n");
@@ -30,6 +43,15 @@ pub fn after_help(rayon_env: bool) -> String {
 
     #[cfg(feature = "zstd")]
     s.push_str(color_print::cstr!("  <cyan, bold>zstd\n"));
+
+    s.push_str(&after_help_common(rayon_env));
+
+    s
+}
+
+#[doc(hidden)]
+pub fn after_help_common(rayon_env: bool) -> String {
+    let mut s = String::new();
 
     s.push_str(color_print::cstr!("<green, bold>Environment Variables:\n"));
     s.push_str(color_print::cstr!("  <cyan, bold>RUST_LOG:"));

--- a/backhand-cli/src/parse.rs
+++ b/backhand-cli/src/parse.rs
@@ -1,0 +1,120 @@
+//! Parse helpers for mksquashfs-backhand
+
+use std::{ffi::CString, num::ParseIntError, str::FromStr};
+
+use backhand::compression::{Compressor, XzFilter};
+
+pub fn parse_block_size(arg: &str) -> Result<u32, <u32 as FromStr>::Err> {
+    let multiplier = if arg.ends_with("K") {
+        bytesize::KIB as u32
+    } else if arg.ends_with("M") {
+        bytesize::MIB as u32
+    } else {
+        1
+    };
+    arg.trim_end_matches(['K', 'M']).parse().map(|out: u32| out * multiplier)
+}
+
+pub fn parse_compressor(arg: &str) -> Result<Compressor, &'static str> {
+    match arg {
+        "gzip" => Ok(Compressor::Gzip),
+        "lzo" => Ok(Compressor::Lzo),
+        "lz4" => Ok(Compressor::Lz4),
+        "xz" => Ok(Compressor::Xz),
+        "zstd" => Ok(Compressor::Zstd),
+        _ => Err("Invalid compressor! Possible values are: gzip, lzo, lz4, xz, zstd"),
+    }
+}
+
+pub fn parse_octal(arg: &str) -> Result<u16, ParseIntError> {
+    u16::from_str_radix(arg, 8)
+}
+
+pub fn parse_uid(arg: &str) -> Result<u32, String> {
+    let uid = match arg.parse::<u32>() {
+        Ok(uid) => uid,
+        #[cfg(target_family = "unix")]
+        Err(_e) => {
+            let passwd = unsafe { libc::getpwnam(CString::new(arg).unwrap().as_ptr()) };
+            if passwd.is_null() {
+                return Err(format!("Invalid uid or username {arg}"));
+            }
+            unsafe { (*passwd).pw_uid }
+        }
+        #[cfg(not(target_family = "unix"))]
+        Err(_e) => return Err(format!("Invalid uid {arg}: e")),
+    };
+    Ok(uid)
+}
+
+pub fn parse_gid(arg: &str) -> Result<u32, String> {
+    let gid = match arg.parse::<u32>() {
+        Ok(gid) => gid,
+        #[cfg(target_family = "unix")]
+        Err(_e) => {
+            let passwd = unsafe { libc::getgrnam(CString::new(arg).unwrap().as_ptr()) };
+            if passwd.is_null() {
+                return Err(format!("Invalid gid or group name {arg}"));
+            }
+            unsafe { (*passwd).gr_gid }
+        }
+        #[cfg(not(target_family = "unix"))]
+        Err(_e) => return Err(format!("Invalid gid {arg}: e")),
+    };
+    Ok(gid)
+}
+
+pub fn parse_xz_filter(arg: &str) -> Result<XzFilter, String> {
+    let mut filter = XzFilter::default();
+    let filters = arg.split(',');
+    for filter_str in filters.map(str::trim) {
+        match filter_str {
+            "x86" => filter.with_x86(),
+            "arm" => filter.with_arm(),
+            "armthumb" => filter.with_armthumb(),
+            "powerpc" => filter.with_powerpc(),
+            "sparc" => filter.with_sparc(),
+            "ia64" => filter.with_ia64(),
+            _ => Err(format!("Invalid branch/call/jump filter {filter_str}"))?,
+        }
+    }
+
+    Ok(filter)
+}
+
+pub fn parse_xz_dict_size(arg: &str) -> Result<u32, String> {
+    let multiplier = if arg.ends_with("K") {
+        bytesize::KIB as u32
+    } else if arg.ends_with("M") {
+        bytesize::MIB as u32
+    } else {
+        1
+    };
+    let number = arg
+        .trim_end_matches(['K', 'M'])
+        .parse()
+        .map(|out: u32| out * multiplier)
+        .map_err(|e| format!("Invalid dict size {arg}: {e}"))?;
+
+    if (number as u64) < bytesize::KIB * 8 {
+        Err(format!("Invalid dict size {arg}. The dict size must be at least 8KiB"))
+    } else {
+        // Dict size must be either 2^n or 3*2^n
+        let is_power_2 = number & (number - 1) == 0;
+        let is_power_2_times_3 = (number / 3) & (number / 3 - 1) == 0;
+        if is_power_2 && is_power_2_times_3 {
+            Ok(number)
+        } else {
+            Err(format!("Invalid dict size {arg}. The dict size must be a power of two or a power of two multiplied by 3"))
+        }
+    }
+}
+
+pub fn parse_window_size(arg: &str) -> Result<u16, String> {
+    let value = arg.parse::<u16>().map_err(|e| format!("Invalid window size {arg}: {e}"))?;
+    if !(1..=15).contains(&value) {
+        Err(format!("Invalid window size {value}. Window size must be in the range [1, 15]"))
+    } else {
+        Ok(value)
+    }
+}

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -19,8 +19,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 deku = { version = "0.19.1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.40" }
 thiserror = "2.0.1"
-flate2 = { version = "1.1.0", optional = true, default-features = false, features = ["zlib-rs"] }
-liblzma = { version = "0.4.1", optional = true, default-features = false, features = ["static", "parallel"] }
+flate2 = { version = "1.1.0", optional = true, default-features = false, features = [
+    "zlib-rs",
+] }
+liblzma = { version = "0.4.1", optional = true, default-features = false, features = [
+    "static",
+    "parallel",
+] }
 rust-lzo = { version = "0.6.2", optional = true }
 zstd = { version = "0.13.2", optional = true }
 zstd-safe = { version = "7.2.1", optional = true }
@@ -55,7 +60,7 @@ parallel = ["dep:rayon"]
 test-log = { version = "0.2.16", features = ["trace"] }
 test-assets-ureq = "0.3.0"
 assert_cmd = { version = "2.0.16", features = ["color", "color-auto"] }
-dir-diff = { git  = "https://github.com/wcampbell0x2a/dir-diff", branch = "add-checking-permissions" }
+dir-diff = { git = "https://github.com/wcampbell0x2a/dir-diff", branch = "add-checking-permissions" }
 tempfile = "3.14.0"
 criterion = "0.6"
 libdeflater = "1.22.0"

--- a/backhand/src/compressor.rs
+++ b/backhand/src/compressor.rs
@@ -95,33 +95,57 @@ pub struct Xz {
     pub fb: Option<u16>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, DekuRead, DekuWrite)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, DekuRead, DekuWrite)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 pub struct XzFilter(u32);
 
 impl XzFilter {
-    fn x86(&self) -> bool {
+    pub fn x86(&self) -> bool {
         self.0 & 0x0001 == 0x0001
     }
 
-    fn powerpc(&self) -> bool {
+    pub fn with_x86(&mut self) {
+        self.0 &= 0x0001;
+    }
+
+    pub fn powerpc(&self) -> bool {
         self.0 & 0x0002 == 0x0002
     }
 
-    fn ia64(&self) -> bool {
+    pub fn with_powerpc(&mut self) {
+        self.0 &= 0x0002;
+    }
+
+    pub fn ia64(&self) -> bool {
         self.0 & 0x0004 == 0x0004
     }
 
-    fn arm(&self) -> bool {
+    pub fn with_ia64(&mut self) {
+        self.0 &= 0x0004;
+    }
+
+    pub fn arm(&self) -> bool {
         self.0 & 0x0008 == 0x0008
     }
 
-    fn armthumb(&self) -> bool {
+    pub fn with_arm(&mut self) {
+        self.0 &= 0x0008;
+    }
+
+    pub fn armthumb(&self) -> bool {
         self.0 & 0x0010 == 0x0010
     }
 
-    fn sparc(&self) -> bool {
+    pub fn with_armthumb(&mut self) {
+        self.0 &= 0x0010;
+    }
+
+    pub fn sparc(&self) -> bool {
         self.0 & 0x0020 == 0x0020
+    }
+
+    pub fn with_sparc(&mut self) {
+        self.0 &= 0x0020;
     }
 }
 

--- a/backhand/src/lib.rs
+++ b/backhand/src/lib.rs
@@ -106,6 +106,6 @@ pub mod kind {
 pub mod compression {
     pub use crate::compressor::{
         CompressionAction, CompressionOptions, Compressor, DefaultCompressor, Gzip, Lz4, Lzo, Xz,
-        Zstd,
+        XzFilter, Zstd,
     };
 }


### PR DESCRIPTION
Closes #21.

Adds an `mksquashfs-backhand` tool similar to squashfs-tools' `mksquashfs`. This implementation does not aim for drop-in compatibility, and I changed some defaults and arguments where I thought it sane to do so. It also does not provide a reimplementation of every mksquashfs option yet.

I have not extensively tested every implemented option, but it appears to do the job of making a basic squashfs well enough.

### TODO

- [ ] Test
- [ ] Add automated tests
- [ ] Benchmark