### PR TITLE
Add `remove_entry` function to squashfs writer

### DIFF
--- a/backhand-test/Cargo.toml
+++ b/backhand-test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dev-dependencies]
 backhand = { path = "../backhand", default-features = false }
 assert_cmd = { version = "2.0.16", features = ["color", "color-auto"] }
-dir-diff = { git  = "https://github.com/wcampbell0x2a/dir-diff", branch = "add-checking-permissions" }
+dir-diff = { git = "https://github.com/wcampbell0x2a/dir-diff", branch = "add-checking-permissions" }
 tempfile = "3.14.0"
 test-assets-ureq = "0.3.0"
 test-log = { version = "0.2.16", features = ["trace"] }
@@ -54,3 +54,6 @@ name = "replace"
 
 [[test]]
 name = "unsquashfs"
+
+[[test]]
+name = "remove"

--- a/backhand-test/tests/remove.rs
+++ b/backhand-test/tests/remove.rs
@@ -1,0 +1,65 @@
+use std::io::{Cursor, Seek, SeekFrom};
+
+use backhand::{FilesystemReader, FilesystemWriter, InnerNode, Node, NodeHeader, SquashfsDir};
+
+mod common;
+
+/// Removing a file should work as expected
+#[test]
+fn test_remove_single_file() {
+    let mut writer = FilesystemWriter::default();
+    let dummy_file = Cursor::new(&[1, 2, 3]);
+    let dummy_header = NodeHeader::new(0, 0, 0, 0);
+    writer.push_dir("/test", dummy_header).unwrap();
+    writer.push_file(dummy_file, "/test/file", dummy_header).unwrap();
+
+    writer.remove_entry("/test/file").unwrap();
+    let mut out_buffer = Cursor::new(vec![]);
+    writer.write(&mut out_buffer).unwrap();
+    drop(writer);
+
+    out_buffer.seek(std::io::SeekFrom::Start(0)).unwrap();
+    let reader = FilesystemReader::from_reader(out_buffer).unwrap();
+    assert_eq!(
+        reader.root.nodes,
+        vec![
+            Node::new_root(dummy_header),
+            Node {
+                fullpath: "/test".into(),
+                header: dummy_header,
+                inner: InnerNode::Dir(SquashfsDir {})
+            }
+        ]
+    );
+}
+
+/// Removing a directory should also remove its children
+#[test]
+fn test_remove_children() {
+    let mut writer = FilesystemWriter::default();
+    let mut dummy_file = Cursor::new(&[1, 2, 3]);
+    let dummy_header = NodeHeader::new(0, 0, 0, 0);
+    writer.push_dir_all("/test/deeper", dummy_header).unwrap();
+    writer.push_file(dummy_file.clone(), "/test/deeper/file", dummy_header).unwrap();
+    dummy_file.seek(SeekFrom::Start(0)).unwrap();
+    writer.push_file(dummy_file, "/test/deeper/file2", dummy_header).unwrap();
+
+    writer.remove_entry("/test/deeper").unwrap();
+    let mut out_buffer = Cursor::new(vec![]);
+    writer.write(&mut out_buffer).unwrap();
+    drop(writer);
+
+    out_buffer.seek(SeekFrom::Start(0)).unwrap();
+    let reader = FilesystemReader::from_reader(out_buffer).unwrap();
+    assert_eq!(
+        reader.root.nodes,
+        vec![
+            Node::new_root(dummy_header),
+            Node {
+                fullpath: "/test".into(),
+                header: dummy_header,
+                inner: InnerNode::Dir(SquashfsDir {})
+            }
+        ]
+    );
+}

--- a/backhand/src/filesystem/writer.rs
+++ b/backhand/src/filesystem/writer.rs
@@ -325,6 +325,14 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
         Ok(())
     }
 
+    /// Remove an existing entry. If `remove_path` is a directory, its children will be removed as well.
+    pub fn remove_entry<S: AsRef<Path>>(&mut self, remove_path: S) -> Result<(), BackhandError>
+    where
+        S: AsRef<Path>,
+    {
+        self.root.remove(remove_path)
+    }
+
     /// Insert symlink `path` -> `link`
     ///
     /// The `uid` and `gid` in `header` are added to FilesystemWriters id's


### PR DESCRIPTION
Adds a means to remove files and folders from an existing squashfs writer. The intended use case is for writers which have been created from a reader, but contain unwanted files, which is something I am encountering in another project.