### PR TITLE
Use parking_lot instead of std::sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "libdeflater",
  "liblzma",
  "lz4_flex",
+ "parking_lot",
  "rayon",
  "rust-lzo",
  "solana-nohash-hasher",
@@ -145,6 +146,7 @@ dependencies = [
  "jemallocator",
  "libc",
  "nix",
+ "parking_lot",
  "rayon",
  "tracing",
  "tracing-subscriber",
@@ -1076,6 +1078,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1227,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1373,6 +1408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1557,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/backhand-cli/Cargo.toml
+++ b/backhand-cli/Cargo.toml
@@ -24,6 +24,7 @@ backhand = { path = "../backhand", default-features = false, version = "0.23.0" 
 tracing = "0.1.40"
 color-print = "0.3.6"
 clap-cargo = "0.15.0"
+parking_lot = "0.12.4"
 
 [lib]
 bench = false

--- a/backhand-cli/src/bin/unsquashfs.rs
+++ b/backhand-cli/src/bin/unsquashfs.rs
@@ -5,7 +5,6 @@ use std::os::unix::fs::lchown;
 use std::os::unix::prelude::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::ExitCode;
-use std::sync::Mutex;
 
 use backhand::kind::Kind;
 use backhand::{
@@ -23,6 +22,7 @@ use nix::libc::geteuid;
 use nix::sys::stat::{dev_t, mknod, mode_t, umask, utimensat, utimes, Mode, SFlag, UtimensatFlags};
 use nix::sys::time::{TimeSpec, TimeVal};
 use nix::unistd::mkfifo;
+use parking_lot::Mutex;
 use rayon::prelude::*;
 use std::time::{Duration, Instant};
 
@@ -439,7 +439,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
         let path = &node.fullpath;
         let fullpath = path.strip_prefix(Component::RootDir).unwrap_or(path);
         if !args.quiet {
-            let mut p = processing.lock().unwrap();
+            let mut p = processing.lock();
             p.insert(fullpath);
             pb.set_message(
                 p.iter()
@@ -461,7 +461,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                 if !args.force && filepath.exists() {
                     if !args.quiet {
                         exists(&pb, filepath.to_str().unwrap());
-                        let mut p = processing.lock().unwrap();
+                        let mut p = processing.lock();
                         p.remove(fullpath);
                     }
                     return;
@@ -484,7 +484,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                         if !args.quiet {
                             let line = format!("{} : {e}", filepath.to_str().unwrap());
                             failed(&pb, &line);
-                            let mut p = processing.lock().unwrap();
+                            let mut p = processing.lock();
                             p.remove(fullpath);
                         }
                         return;
@@ -498,7 +498,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                 // check if file exists
                 if !args.force && filepath.exists() {
                     exists(&pb, filepath.to_str().unwrap());
-                    let mut p = processing.lock().unwrap();
+                    let mut p = processing.lock();
                     p.remove(fullpath);
                     return;
                 }
@@ -515,7 +515,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                             let line =
                                 format!("{}->{link_display} : {e}", filepath.to_str().unwrap());
                             failed(&pb, &line);
-                            let mut p = processing.lock().unwrap();
+                            let mut p = processing.lock();
                             p.remove(fullpath);
                         }
                         return;
@@ -538,7 +538,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                                 );
                                 failed(&pb, &line);
                             }
-                            let mut p = processing.lock().unwrap();
+                            let mut p = processing.lock();
                             p.remove(fullpath);
                             return;
                         }
@@ -589,7 +589,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                                     filepath.to_str().unwrap()
                                 );
                                 failed(&pb, &line);
-                                let mut p = processing.lock().unwrap();
+                                let mut p = processing.lock();
                                 p.remove(fullpath);
                             }
                             return;
@@ -603,7 +603,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                         );
                         failed(&pb, &line);
                     }
-                    let mut p = processing.lock().unwrap();
+                    let mut p = processing.lock();
                     p.remove(fullpath);
                     return;
                 }
@@ -626,7 +626,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                     Err(_) => {
                         if args.info && !args.quiet {
                             created(&pb, filepath.to_str().unwrap());
-                            let mut p = processing.lock().unwrap();
+                            let mut p = processing.lock();
                             p.remove(fullpath);
                         }
                         return;
@@ -649,7 +649,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                         if args.info && !args.quiet {
                             created(&pb, filepath.to_str().unwrap());
                         }
-                        let mut p = processing.lock().unwrap();
+                        let mut p = processing.lock();
                         p.remove(fullpath);
                         return;
                     }
@@ -673,7 +673,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                     Err(_) => {
                         if args.info && !args.quiet {
                             created(&pb, filepath.to_str().unwrap());
-                            let mut p = processing.lock().unwrap();
+                            let mut p = processing.lock();
                             p.remove(fullpath);
                         }
                         return;
@@ -681,7 +681,7 @@ fn extract_all<'a, S: ParallelIterator<Item = &'a Node<SquashfsFileReader>>>(
                 }
             }
         }
-        let mut p = processing.lock().unwrap();
+        let mut p = processing.lock();
         p.remove(fullpath);
     });
 

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -29,6 +29,7 @@ xxhash-rust = { version = "0.8.12", features = ["xxh64"] }
 solana-nohash-hasher = "0.2.1"
 lz4_flex = { version = "0.11.3", optional = true, default-features = false }
 rayon = { version = "1.10.0", optional = true, default-features = false }
+parking_lot = "0.12.4"
 
 [features]
 default = ["xz", "gzip", "zstd", "lz4", "parallel"]

--- a/backhand/src/filesystem/node.rs
+++ b/backhand/src/filesystem/node.rs
@@ -2,12 +2,14 @@ use core::fmt;
 use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use super::normalize_squashfs_path;
 use crate::data::Added;
 use crate::inode::{BasicFile, ExtendedFile, InodeHeader};
 use crate::{BackhandError, DataSize, FilesystemReaderFile, Id};
+
+use parking_lot::Mutex;
 
 /// File information for Node
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]

--- a/backhand/src/filesystem/reader.rs
+++ b/backhand/src/filesystem/reader.rs
@@ -1,4 +1,4 @@
-use std::sync::{Mutex, RwLock};
+use parking_lot::{Mutex, RwLock};
 
 use super::node::Nodes;
 use crate::compressor::{CompressionOptions, Compressor};

--- a/backhand/src/filesystem/writer.rs
+++ b/backhand/src/filesystem/writer.rs
@@ -3,10 +3,10 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use deku::prelude::*;
+use parking_lot::Mutex;
 use tracing::{error, info, trace};
 
 use super::node::{InnerNode, Nodes};
@@ -475,7 +475,7 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
             let (filesize, added) = match file {
                 SquashfsFileWriter::UserDefined(file) => {
                     let file_ptr = Arc::clone(file);
-                    let mut file_lock = file_ptr.lock().unwrap();
+                    let mut file_lock = file_ptr.lock();
                     data_writer.add_bytes(&mut *file_lock, &mut writer)?
                 }
                 SquashfsFileWriter::SquashfsFile(file) => {

--- a/backhand/src/squashfs.rs
+++ b/backhand/src/squashfs.rs
@@ -3,10 +3,10 @@
 use std::ffi::OsString;
 use std::io::{Cursor, Seek, SeekFrom};
 use std::path::PathBuf;
-use std::sync::Mutex;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use deku::prelude::*;
+use parking_lot::{Mutex, RwLock};
 use solana_nohash_hasher::IntMap;
 use tracing::{error, info, trace};
 


### PR DESCRIPTION
In my tests, this gave a nice (5-10%) performance boost. `Mutex` and `RwLock` never appear in public APIs, so this does not break compatibility.