### PR TITLE
Replace rust-lzo (GPL) with lzokay (MIT) for LZO compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
  "lz4_flex",
  "lzma-adaptive-sys",
  "lzma-rust2",
+ "lzokay",
  "no_std_io2",
  "rayon",
- "rust-lzo",
  "solana-nohash-hasher",
  "tempfile",
  "test-assets-ureq",
@@ -1228,6 +1228,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzokay"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953d350dc065718bb00b61ea2118274ffe2fdf6488f32f720422bcd1c9d6025f"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,15 +1589,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rust-lzo"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf191ab1b954757cb5bb7f366e17d80daaa06010f1fdde7a3a7db052c1ecd1a8"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/backhand-cli/Cargo.toml
+++ b/backhand-cli/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.5.4"
 
 # These features mirror the backhand features
 [features]
-default = ["xz", "gzip", "zstd"]
+default = ["xz", "gzip", "lzo", "zstd"]
 ## Enables squashfs v3
 v3 = ["backhand/v3"]
 ## Enables squashfs v3 with LZMA compression
@@ -44,7 +44,7 @@ xz-static = ["xz", "backhand/xz-static"]
 ## Enables gzip compression inside library and binaries
 any-gzip = []
 gzip = ["any-gzip", "backhand/gzip"]
-## This library is licensed GPL and thus disabled by default
+## Enables lzo compression inside library and binaries
 lzo = ["backhand/lzo"]
 ## Enables zstd compression inside library and binaries
 zstd = ["backhand/zstd"]

--- a/backhand-test/Cargo.toml
+++ b/backhand-test/Cargo.toml
@@ -27,14 +27,13 @@ bench = false
 [features]
 # testing only feature for testing vs squashfs-tools/unsquashfs
 __test_unsquashfs = []
-default = ["xz", "gzip", "zstd"]
+default = ["xz", "gzip", "lzo", "zstd"]
 v3 = ["backhand/v3"]
 v3_lzma = ["backhand/v3", "backhand/v3_lzma"]
 xz = ["backhand/xz"]
 xz-static = ["backhand/xz-static"]
 any-gzip = []
 gzip = ["any-gzip", "backhand/gzip"]
-# this library is licensed GPL and thus disabled by default
 lzo = ["backhand/lzo"]
 zstd = ["backhand/zstd"]
 lz4 = ["backhand/lz4"]

--- a/backhand/Cargo.toml
+++ b/backhand/Cargo.toml
@@ -12,7 +12,7 @@ description = "Library for the reading, creating, and modification of SquashFS f
 readme = "../README.md"
 
 [package.metadata.docs.rs]
-features = ["xz", "gzip", "zstd", "document-features", "v3", "v3_lzma"]
+features = ["xz", "gzip", "lzo", "zstd", "document-features", "v3", "v3_lzma"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
@@ -23,7 +23,7 @@ flate2 = { version = "1.1.0", optional = true, default-features = false, feature
 liblzma = { version = "0.4.1", optional = true, default-features = false, features = ["static", "parallel"] }
 lzma-adaptive-sys = { version = "0.1.0", optional = true }
 lzma-rust2 = { version = "0.16.0", optional = true, features = ["xz", "encoder", "optimization"] }
-rust-lzo = { version = "0.6.2", optional = true }
+lzokay = { version = "2.0.1", optional = true }
 zstd = { version = "0.13.2", optional = true }
 zstd-safe = { version = "7.2.1", optional = true }
 document-features = { version = "0.2.10", optional = true }
@@ -34,7 +34,7 @@ rayon = { version = "1.10.0", optional = true, default-features = false }
 no_std_io2 = "0.9.0"
 
 [features]
-default = ["xz", "gzip", "zstd", "lz4", "parallel"]
+default = ["xz", "gzip", "lzo", "zstd", "lz4", "parallel"]
 ## Enables squashfs v3
 v3 = ["gzip"]
 ## Enables squashfs v3 with LZMA compression
@@ -45,8 +45,8 @@ xz = ["dep:liblzma"]
 xz-static = ["dep:liblzma", "liblzma?/static"]
 ## Enables gzip compression inside library and binaries using flate2 library with zlib-rs
 gzip = ["any-gzip", "dep:flate2"]
-## This library is licensed GPL and thus disabled by default
-lzo = ["dep:rust-lzo"]
+## Enables lzo compression inside library and binaries
+lzo = ["dep:lzokay"]
 ## Enables zstd compression inside library and binaries
 zstd = ["dep:zstd", "dep:zstd-safe"]
 ## Enables Lz4 compression

--- a/backhand/src/v4/compressor.rs
+++ b/backhand/src/v4/compressor.rs
@@ -175,12 +175,9 @@ impl CompressionAction for DefaultCompressor {
             #[cfg(feature = "lzo")]
             Compressor::Lzo => {
                 out.resize(out.capacity(), 0);
-                let (out_size, error) = rust_lzo::LZOContext::decompress_to_slice(bytes, out);
-                let out_size = out_size.len();
+                let out_size = lzokay::decompress::decompress(bytes, out)
+                    .map_err(|_| BackhandError::CorruptedOrInvalidSquashfs)?;
                 out.truncate(out_size);
-                if error != rust_lzo::LZOError::OK {
-                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
-                }
             }
             #[cfg(feature = "zstd")]
             Compressor::Zstd => {
@@ -289,15 +286,8 @@ impl CompressionAction for DefaultCompressor {
                 Ok(buf)
             }
             #[cfg(feature = "lzo")]
-            (Compressor::Lzo, _, _) => {
-                let mut lzo = rust_lzo::LZOContext::new();
-                let mut buf = vec![0; rust_lzo::worst_compress(bytes.len())];
-                let error = lzo.compress(bytes, &mut buf);
-                if error != rust_lzo::LZOError::OK {
-                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
-                }
-                Ok(buf)
-            }
+            (Compressor::Lzo, _, _) => lzokay::compress::compress(bytes)
+                .map_err(|_| BackhandError::CorruptedOrInvalidSquashfs),
             #[cfg(feature = "zstd")]
             (Compressor::Zstd, option @ (Some(CompressionOptions::Zstd(_)) | None), _) => {
                 let compression_level = match option {


### PR DESCRIPTION
Hello,

Would it be an option to use lzokay in backhand as a replacement for rust-lzo and thus enable lzo support by default?

Thanks!