### PR TITLE
Reject wrong sizes and indices in the block reader

### DIFF
--- a/backhand/src/v3/filesystem/reader.rs
+++ b/backhand/src/v3/filesystem/reader.rs
@@ -190,10 +190,19 @@ impl<'a, 'b> FilesystemReaderFile<'a, 'b> {
     }
 
     pub fn fragment(&self) -> Option<&'a Fragment> {
+        self.fragment_checked().ok().flatten()
+    }
+
+    pub(crate) fn fragment_checked(&self) -> Result<Option<&'a Fragment>, BackhandError> {
         if self.file.frag_index() == 0xffffffff {
-            None
-        } else {
-            self.system.fragments.as_ref().map(|fragments| &fragments[self.file.frag_index()])
+            return Ok(None);
+        }
+        match self.system.fragments.as_ref() {
+            None => Ok(None),
+            Some(fragments) => fragments
+                .get(self.file.frag_index())
+                .map(Some)
+                .ok_or(BackhandError::CorruptedOrInvalidSquashfs),
         }
     }
 

--- a/backhand/src/v3/filesystem/reader_no_parallel.rs
+++ b/backhand/src/v3/filesystem/reader_no_parallel.rs
@@ -36,6 +36,9 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     *data = vec![0; self.file.system.block_size as usize];
                     return Ok(RawDataBlock { fragment: false, uncompressed: true });
                 }
+                if block_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(block_size, 0);
                 //NOTE: storing/restoring the file-pos is not required at the
                 //moment of writing, but in the future, it may.
@@ -53,7 +56,7 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     let cache = self.file.system.cache.read().unwrap();
                     if let Some(cache_bytes) = cache.fragment_cache.get(&fragment.start) {
                         //if in cache, just return the cache, don't read it
-                        let range = self.fragment_range();
+                        let range = self.fragment_range(cache_bytes.len())?;
                         tracing::trace!("fragment in cache: {:02x}:{range:02x?}", fragment.start);
                         data.resize(range.end - range.start, 0);
                         data.copy_from_slice(&cache_bytes[range]);
@@ -68,6 +71,9 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                 // that were read that are for the file
                 tracing::trace!("fragment: reading from data");
                 let frag_size = fragment.size.size() as usize;
+                if frag_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(frag_size, 0);
                 {
                     let mut reader = self.file.system.reader.lock().unwrap();
@@ -77,16 +83,16 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
 
                 // if already decompressed, store
                 if fragment.size.uncompressed() {
+                    let range = self.fragment_range(data.len())?;
                     self.file
                         .system
                         .cache
                         .write()
                         .unwrap()
                         .fragment_cache
-                        .insert(self.file.fragment().unwrap().start, data.clone());
+                        .insert(fragment.start, data.clone());
 
                     //apply the fragment offset
-                    let range = self.fragment_range();
                     data.drain(range.end..);
                     data.drain(..range.start);
                 }
@@ -113,15 +119,20 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
         }
     }
 
+    /// Compute the byte range of this file's tail data within the fragment block.
     #[inline]
-    fn fragment_range(&self) -> std::ops::Range<usize> {
+    fn fragment_range(&self, frag_buf_len: usize) -> Result<std::ops::Range<usize>, BackhandError> {
         let block_len = self.file.system.block_size as usize;
         let block_num = self.file.file.block_sizes().len();
         let file_size = self.file.file.file_len();
-        let frag_len = file_size - (block_num * block_len);
         let frag_start = self.file.file.block_offset() as usize;
-        let frag_end = frag_start + frag_len;
-        frag_start..frag_end
+
+        (|| {
+            let frag_len = file_size.checked_sub(block_num.checked_mul(block_len)?)?;
+            let frag_end = frag_start.checked_add(frag_len)?;
+            (frag_end <= frag_buf_len).then_some(frag_start..frag_end)
+        })()
+        .ok_or(BackhandError::CorruptedOrInvalidSquashfs)
     }
 
     pub fn decompress(
@@ -145,16 +156,20 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
             )?;
             // store the cache, so decompression is not duplicated
             if data.fragment {
+                let fragment = self
+                    .file
+                    .fragment_checked()?
+                    .ok_or(BackhandError::CorruptedOrInvalidSquashfs)?;
+                //apply the fragment offset
+                let range = self.fragment_range(output_buf.len())?;
                 self.file
                     .system
                     .cache
                     .write()
                     .unwrap()
                     .fragment_cache
-                    .insert(self.file.fragment().unwrap().start, output_buf.clone());
+                    .insert(fragment.start, output_buf.clone());
 
-                //apply the fragment offset
-                let range = self.fragment_range();
                 output_buf.drain(range.end..);
                 output_buf.drain(..range.start);
             }

--- a/backhand/src/v3/filesystem/reader_parallel.rs
+++ b/backhand/src/v3/filesystem/reader_parallel.rs
@@ -70,6 +70,9 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     *data = vec![0; self.file.system.block_size as usize];
                     return Ok(RawDataBlock { fragment: false, uncompressed: true });
                 }
+                if block_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(block_size, 0);
                 //NOTE: storing/restoring the file-pos is not required at the
                 //moment of writing, but in the future, it may.
@@ -87,7 +90,7 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     let cache = self.file.system.cache.read().unwrap();
                     if let Some(cache_bytes) = cache.fragment_cache.get(&fragment.start) {
                         //if in cache, just return the cache, don't read it
-                        let range = self.fragment_range();
+                        let range = self.fragment_range(cache_bytes.len())?;
                         tracing::trace!("fragment in cache: {:02x}:{range:02x?}", fragment.start);
                         data.resize(range.end - range.start, 0);
                         data.copy_from_slice(&cache_bytes[range]);
@@ -97,11 +100,11 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     }
                 }
 
-                // if not in the cache, read the entire fragment bytes to store into
-                // the cache. Once that is done, if uncompressed just return the bytes
-                // that were read that are for the file
                 tracing::trace!("fragment: reading from data");
                 let frag_size = fragment.size.size() as usize;
+                if frag_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(frag_size, 0);
                 {
                     let mut reader = self.file.system.reader.lock().unwrap();
@@ -111,16 +114,16 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
 
                 // if already decompressed, store
                 if fragment.size.uncompressed() {
+                    let range = self.fragment_range(data.len())?;
                     self.file
                         .system
                         .cache
                         .write()
                         .unwrap()
                         .fragment_cache
-                        .insert(self.file.fragment().unwrap().start, data.clone());
+                        .insert(fragment.start, data.clone());
 
                     //apply the fragment offset
-                    let range = self.fragment_range();
                     data.drain(range.end..);
                     data.drain(..range.start);
                 }
@@ -165,15 +168,23 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
         }
     }
 
+    /// Compute the byte range of this file's tail data within the fragment block.
     #[inline]
-    fn fragment_range(&self) -> core::ops::Range<usize> {
+    fn fragment_range(
+        &self,
+        frag_buf_len: usize,
+    ) -> Result<core::ops::Range<usize>, BackhandError> {
         let block_len = self.file.system.block_size as usize;
         let block_num = self.file.file.block_sizes().len();
         let file_size = self.file.file.file_len();
-        let frag_len = file_size - (block_num * block_len);
         let frag_start = self.file.file.block_offset() as usize;
-        let frag_end = frag_start + frag_len;
-        frag_start..frag_end
+
+        (|| {
+            let frag_len = file_size.checked_sub(block_num.checked_mul(block_len)?)?;
+            let frag_end = frag_start.checked_add(frag_len)?;
+            (frag_end <= frag_buf_len).then_some(frag_start..frag_end)
+        })()
+        .ok_or(BackhandError::CorruptedOrInvalidSquashfs)
     }
 
     /// Decompress function that can be run in parallel
@@ -198,16 +209,20 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
             )?;
             // store the cache, so decompression is not duplicated
             if data.fragment {
+                let fragment = self
+                    .file
+                    .fragment_checked()?
+                    .ok_or(BackhandError::CorruptedOrInvalidSquashfs)?;
+                //apply the fragment offset
+                let range = self.fragment_range(output_buf.len())?;
                 self.file
                     .system
                     .cache
                     .write()
                     .unwrap()
                     .fragment_cache
-                    .insert(self.file.fragment().unwrap().start, output_buf.clone());
+                    .insert(fragment.start, output_buf.clone());
 
-                //apply the fragment offset
-                let range = self.fragment_range();
                 output_buf.drain(range.end..);
                 output_buf.drain(..range.start);
             }

--- a/backhand/src/v4/filesystem/reader.rs
+++ b/backhand/src/v4/filesystem/reader.rs
@@ -193,10 +193,19 @@ impl<'a, 'b> FilesystemReaderFile<'a, 'b> {
     }
 
     pub fn fragment(&self) -> Option<&'a Fragment> {
+        self.fragment_checked().ok().flatten()
+    }
+
+    pub(crate) fn fragment_checked(&self) -> Result<Option<&'a Fragment>, BackhandError> {
         if self.file.frag_index() == 0xffffffff {
-            None
-        } else {
-            self.system.fragments.as_ref().map(|fragments| &fragments[self.file.frag_index()])
+            return Ok(None);
+        }
+        match self.system.fragments.as_ref() {
+            None => Ok(None),
+            Some(fragments) => fragments
+                .get(self.file.frag_index())
+                .map(Some)
+                .ok_or(BackhandError::CorruptedOrInvalidSquashfs),
         }
     }
 

--- a/backhand/src/v4/filesystem/reader_no_parallel.rs
+++ b/backhand/src/v4/filesystem/reader_no_parallel.rs
@@ -36,6 +36,9 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     *data = vec![0; self.file.system.block_size as usize];
                     return Ok(RawDataBlock { fragment: false, uncompressed: true });
                 }
+                if block_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(block_size, 0);
                 //NOTE: storing/restoring the file-pos is not required at the
                 //moment of writing, but in the future, it may.
@@ -53,7 +56,7 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     let cache = self.file.system.cache.read().unwrap();
                     if let Some(cache_bytes) = cache.fragment_cache.get(&fragment.start) {
                         //if in cache, just return the cache, don't read it
-                        let range = self.fragment_range();
+                        let range = self.fragment_range(cache_bytes.len())?;
                         tracing::trace!("fragment in cache: {:02x}:{range:02x?}", fragment.start);
                         data.resize(range.end - range.start, 0);
                         data.copy_from_slice(&cache_bytes[range]);
@@ -63,11 +66,11 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     }
                 }
 
-                // if not in the cache, read the entire fragment bytes to store into
-                // the cache. Once that is done, if uncompressed just return the bytes
-                // that were read that are for the file
                 tracing::trace!("fragment: reading from data");
                 let frag_size = fragment.size.size() as usize;
+                if frag_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(frag_size, 0);
                 {
                     let mut reader = self.file.system.reader.lock().unwrap();
@@ -77,16 +80,16 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
 
                 // if already decompressed, store
                 if fragment.size.uncompressed() {
+                    let range = self.fragment_range(data.len())?;
                     self.file
                         .system
                         .cache
                         .write()
                         .unwrap()
                         .fragment_cache
-                        .insert(self.file.fragment().unwrap().start, data.clone());
+                        .insert(fragment.start, data.clone());
 
                     //apply the fragment offset
-                    let range = self.fragment_range();
                     data.drain(range.end..);
                     data.drain(..range.start);
                 }
@@ -113,15 +116,20 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
         }
     }
 
+    /// Compute the byte range of this file's tail data within the fragment block.
     #[inline]
-    fn fragment_range(&self) -> std::ops::Range<usize> {
+    fn fragment_range(&self, frag_buf_len: usize) -> Result<std::ops::Range<usize>, BackhandError> {
         let block_len = self.file.system.block_size as usize;
         let block_num = self.file.file.block_sizes().len();
         let file_size = self.file.file.file_len();
-        let frag_len = file_size - (block_num * block_len);
         let frag_start = self.file.file.block_offset() as usize;
-        let frag_end = frag_start + frag_len;
-        frag_start..frag_end
+
+        (|| {
+            let frag_len = file_size.checked_sub(block_num.checked_mul(block_len)?)?;
+            let frag_end = frag_start.checked_add(frag_len)?;
+            (frag_end <= frag_buf_len).then_some(frag_start..frag_end)
+        })()
+        .ok_or(BackhandError::CorruptedOrInvalidSquashfs)
     }
 
     pub fn decompress(
@@ -145,16 +153,20 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
             )?;
             // store the cache, so decompression is not duplicated
             if data.fragment {
+                let fragment = self
+                    .file
+                    .fragment_checked()?
+                    .ok_or(BackhandError::CorruptedOrInvalidSquashfs)?;
+                //apply the fragment offset
+                let range = self.fragment_range(output_buf.len())?;
                 self.file
                     .system
                     .cache
                     .write()
                     .unwrap()
                     .fragment_cache
-                    .insert(self.file.fragment().unwrap().start, output_buf.clone());
+                    .insert(fragment.start, output_buf.clone());
 
-                //apply the fragment offset
-                let range = self.fragment_range();
                 output_buf.drain(range.end..);
                 output_buf.drain(..range.start);
             }

--- a/backhand/src/v4/filesystem/reader_parallel.rs
+++ b/backhand/src/v4/filesystem/reader_parallel.rs
@@ -70,6 +70,9 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     *data = vec![0; self.file.system.block_size as usize];
                     return Ok(RawDataBlock { fragment: false, uncompressed: true });
                 }
+                if block_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(block_size, 0);
                 //NOTE: storing/restoring the file-pos is not required at the
                 //moment of writing, but in the future, it may.
@@ -87,7 +90,7 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                     let cache = self.file.system.cache.read().unwrap();
                     if let Some(cache_bytes) = cache.fragment_cache.get(&fragment.start) {
                         //if in cache, just return the cache, don't read it
-                        let range = self.fragment_range();
+                        let range = self.fragment_range(cache_bytes.len())?;
                         tracing::trace!("fragment in cache: {:02x}:{range:02x?}", fragment.start);
                         data.resize(range.end - range.start, 0);
                         data.copy_from_slice(&cache_bytes[range]);
@@ -102,6 +105,9 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
                 // that were read that are for the file
                 tracing::trace!("fragment: reading from data");
                 let frag_size = fragment.size.size() as usize;
+                if frag_size > self.file.system.block_size as usize {
+                    return Err(BackhandError::CorruptedOrInvalidSquashfs);
+                }
                 data.resize(frag_size, 0);
                 {
                     let mut reader = self.file.system.reader.lock().unwrap();
@@ -111,16 +117,16 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
 
                 // if already decompressed, store
                 if fragment.size.uncompressed() {
+                    let range = self.fragment_range(data.len())?;
                     self.file
                         .system
                         .cache
                         .write()
                         .unwrap()
                         .fragment_cache
-                        .insert(self.file.fragment().unwrap().start, data.clone());
+                        .insert(fragment.start, data.clone());
 
                     //apply the fragment offset
-                    let range = self.fragment_range();
                     data.drain(range.end..);
                     data.drain(..range.start);
                 }
@@ -165,15 +171,23 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
         }
     }
 
+    /// Compute the byte range of this file's tail data within the fragment block.
     #[inline]
-    fn fragment_range(&self) -> core::ops::Range<usize> {
+    fn fragment_range(
+        &self,
+        frag_buf_len: usize,
+    ) -> Result<core::ops::Range<usize>, BackhandError> {
         let block_len = self.file.system.block_size as usize;
         let block_num = self.file.file.block_sizes().len();
         let file_size = self.file.file.file_len();
-        let frag_len = file_size - (block_num * block_len);
         let frag_start = self.file.file.block_offset() as usize;
-        let frag_end = frag_start + frag_len;
-        frag_start..frag_end
+
+        (|| {
+            let frag_len = file_size.checked_sub(block_num.checked_mul(block_len)?)?;
+            let frag_end = frag_start.checked_add(frag_len)?;
+            (frag_end <= frag_buf_len).then_some(frag_start..frag_end)
+        })()
+        .ok_or(BackhandError::CorruptedOrInvalidSquashfs)
     }
 
     /// Decompress function that can be run in parallel
@@ -198,16 +212,20 @@ impl<'a, 'b> SquashfsRawData<'a, 'b> {
             )?;
             // store the cache, so decompression is not duplicated
             if data.fragment {
+                let fragment = self
+                    .file
+                    .fragment_checked()?
+                    .ok_or(BackhandError::CorruptedOrInvalidSquashfs)?;
+                //apply the fragment offset
+                let range = self.fragment_range(output_buf.len())?;
                 self.file
                     .system
                     .cache
                     .write()
                     .unwrap()
                     .fragment_cache
-                    .insert(self.file.fragment().unwrap().start, output_buf.clone());
+                    .insert(fragment.start, output_buf.clone());
 
-                //apply the fragment offset
-                let range = self.fragment_range();
                 output_buf.drain(range.end..);
                 output_buf.drain(..range.start);
             }


### PR DESCRIPTION
Remove all places that would panic on malformed-images, and instead return errors or nones.