### PR TITLE
Fix zero-length files written with dangling fragment reference

### DIFF
--- a/backhand-test/Cargo.toml
+++ b/backhand-test/Cargo.toml
@@ -43,6 +43,9 @@ lz4 = ["backhand/lz4"]
 name = "add"
 
 [[test]]
+name = "empty_file"
+
+[[test]]
 name = "issues"
 
 [[test]]

--- a/backhand-test/tests/empty_file.rs
+++ b/backhand-test/tests/empty_file.rs
@@ -1,0 +1,29 @@
+/// Regression test: zero-length files must be encoded with NO fragment
+/// reference (frag_index 0xffffffff). A dangling zero-byte fragment entry
+/// makes the Linux kernel squashfs driver reject the inode with EINVAL on
+/// stat/open, even though userspace readers tolerate it.
+use std::io::Cursor;
+
+use backhand::v4::filesystem::node::InnerNode;
+use backhand::SquashfsFileReader;
+use backhand::{FilesystemReader, FilesystemWriter, NodeHeader};
+use test_log::test;
+
+#[test]
+fn test_empty_file_has_no_fragment_ref() {
+    let mut fs = FilesystemWriter::default();
+    fs.push_file(Cursor::new(vec![]), "empty", NodeHeader::default()).unwrap();
+    fs.push_file(Cursor::new(b"data".to_vec()), "full", NodeHeader::default()).unwrap();
+
+    let mut image = Cursor::new(vec![]);
+    fs.write(&mut image).unwrap();
+    image.set_position(0);
+
+    let fs = FilesystemReader::from_reader(image).unwrap();
+    let node = fs.files().find(|n| n.fullpath.to_string_lossy() == "/empty").unwrap();
+    let InnerNode::File(SquashfsFileReader::Basic(basic)) = &node.inner else {
+        panic!("expected basic file inode");
+    };
+    assert_eq!(basic.file_size, 0);
+    assert_eq!(basic.frag_index, 0xffffffff, "empty file must not reference a fragment");
+}

--- a/backhand/src/v4/data.rs
+++ b/backhand/src/v4/data.rs
@@ -232,6 +232,15 @@ impl<'a> DataWriter<'a> {
         // read entire chunk (file)
         let mut chunk = chunk_reader.read_chunk()?;
 
+        // an empty file must carry no fragment reference: a zero-byte
+        // fragment entry makes the kernel squashfs driver reject the inode
+        // with EINVAL on stat/open (Added::Data with no blocks encodes
+        // frag_index 0xffffffff, matching mksquashfs)
+        if chunk.is_empty() {
+            let blocks_start = writer.stream_position()?;
+            return Ok((0, Added::Data { blocks_start, block_sizes: vec![] }));
+        }
+
         // chunk size not exactly the size of the block
         if chunk.len() != self.block_size as usize {
             // if this doesn't fit in the current fragment bytes


### PR DESCRIPTION
DataWriter::add_bytes() routed empty files through the fragment path, recording a frag_index for a fragment they contribute zero bytes to. Userspace readers tolerate the resulting inode, but the Linux kernel squashfs driver rejects it with EINVAL on stat/open — e.g. repacking an Alpine minirootfs breaks apk entirely, because /lib/apk/db/lock is a zero-length file.

Encode empty files as Added::Data with no blocks instead, which emits frag_index 0xffffffff (no fragment), matching mksquashfs output and the existing behavior of just_copy_it() for empty files.

Adds a regression test asserting the no-fragment encoding round-trips.