### PR TITLE
Fix empty body in the GitHub release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,7 +11,7 @@ env:
   BINS: "add-backhand unsquashfs-backhand replace-backhand"
 
 jobs:
-  # Publish the crates, create the tag, and create the draft GitHub release.
+  # Publish the crates, create the tag, and create the GitHub release.
   release-plz-release:
     name: release-plz release
     runs-on: ubuntu-24.04
@@ -63,7 +63,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Attach the binaries to the draft release that release-plz created.
+  # Attach the binaries to the release that release-plz created. The release is
+  # not a draft, so this action can find it by tag and will not make a new one.
   release-bins:
     name: attach binaries
     needs: release-plz-release
@@ -137,18 +138,3 @@ jobs:
           asset_name: backhand-${{ env.TAG }}-${{ matrix.job.target }}.tar.gz
           tag: ${{ env.TAG }}
           overwrite: true
-
-  # Make the release visible now that it has all of its binaries.
-  publish-release:
-    name: publish release
-    needs: [release-plz-release, release-bins]
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Remove the draft flag from the release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          TAG: ${{ fromJSON(needs.release-plz-release.outputs.releases)[0].tag }}
-        run: gh release edit "$TAG" --draft=false

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,6 @@
 [target.x86_64-unknown-linux-musl]
 pre-build = [
-    "apt update && apt install zlib1g-dev liblzma-dev",
+    "apt update && DEBIAN_FRONTEND=noninteractive apt install -y zlib1g-dev liblzma-dev",
     "git clone https://github.com/plougher/squashfs-tools.git -b squashfs-tools-4.6.1 && cd squashfs-tools/squashfs-tools && CONFIG=1 XZ_SUPPORT=1 GZIP_SUPPORT=1 make && make install",
 ]
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 git_tag_name = "v{{ version }}"
-git_release_draft = true
+git_release_draft = false
 git_release_type = "auto"
 semver_check = true
 pr_labels = ["release"]


### PR DESCRIPTION
release-plz made the release as a draft. The upload action finds a release by tag, but GitHub gives drafts by ID only. The lookup failed, so the action made a second release with an empty body and no name.

Make the release directly, and remove the job that cleared the draft flag.