### PR TITLE
Add lazy file writing for v4

### DIFF
--- a/backhand/src/lib.rs
+++ b/backhand/src/lib.rs
@@ -33,9 +33,9 @@
 //! let bytes = Cursor::new(b"Fear is the mind-killer.");
 //! write_filesystem.push_file(bytes, "a/d/e/new_file", d);
 //!
-//! // add file with data from file
-//! let new_file = File::open("dune").unwrap();
-//! write_filesystem.push_file(new_file, "/root/dune", d);
+//! // add file with data from a file on disk. The file is opened during write(), so an image
+//! // can contain more files than the limit of open file descriptors of the process.
+//! write_filesystem.push_file_from_path("dune", "/root/dune", d);
 //!
 //! // replace a existing file
 //! let bytes = Cursor::new(b"The sleeper must awaken.\n");
@@ -77,8 +77,8 @@ pub use crate::v4::V4;
 pub use crate::v4::data::DataSize;
 pub use crate::v4::export::Export;
 pub use crate::v4::filesystem::node::{
-    InnerNode, Node, NodeHeader, SquashfsBlockDevice, SquashfsCharacterDevice, SquashfsDir,
-    SquashfsFileReader, SquashfsFileWriter, SquashfsSymlink,
+    InnerNode, LazyFile, Node, NodeHeader, SquashfsBlockDevice, SquashfsCharacterDevice,
+    SquashfsDir, SquashfsFileReader, SquashfsFileWriter, SquashfsSymlink,
 };
 pub use crate::v4::filesystem::reader::SquashfsReadFile;
 pub use crate::v4::filesystem::reader::{FilesystemReader, FilesystemReaderFile};

--- a/backhand/src/v4/filesystem/node.rs
+++ b/backhand/src/v4/filesystem/node.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use core::num::NonZeroUsize;
 use no_std_io2::io::Read;
+use std::fs::File;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -134,9 +136,37 @@ impl SquashfsFileReader {
     }
 }
 
+/// File on disk that is opened only when the image is written
+///
+/// A [`FilesystemWriter`](crate::FilesystemWriter) can contain many thousands of files. If each
+/// one held an open [`File`], the image build could go over the limit of open file descriptors of
+/// the process. This holds the path instead and opens the file during the write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LazyFile {
+    path: PathBuf,
+}
+
+impl LazyFile {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Path of the file on disk
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Open the file for the write of the image
+    pub(crate) fn open(&self) -> Result<BufReader<File>, BackhandError> {
+        Ok(BufReader::new(File::open(&self.path)?))
+    }
+}
+
 /// Read file from other SquashfsFile or an user file
 pub enum SquashfsFileWriter<'a, 'b, 'c> {
     UserDefined(Arc<Mutex<dyn Read + 'c>>),
+    /// File on disk, opened only when the image is written
+    LazyFile(LazyFile),
     SquashfsFile(FilesystemReaderFile<'a, 'b>),
     Consumed(usize, Added),
 }

--- a/backhand/src/v4/filesystem/writer.rs
+++ b/backhand/src/v4/filesystem/writer.rs
@@ -16,7 +16,7 @@ use crate::v4::compressor::{CompressionOptions, Compressor};
 use crate::v4::data::DataWriter;
 use crate::v4::entry::Entry;
 use crate::v4::filesystem::node::SquashfsSymlink;
-use crate::v4::filesystem::node::{InnerNode, Nodes};
+use crate::v4::filesystem::node::{InnerNode, LazyFile, Nodes};
 use crate::v4::filesystem::normalize_squashfs_path;
 use crate::v4::fragment;
 use crate::v4::id::Id;
@@ -282,6 +282,10 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
 
     /// Insert `reader` into filesystem with `path` and metadata `header`.
     ///
+    /// The reader is kept until [`Self::write`] is called. For a file on disk, use
+    /// [`Self::push_file_from_path`] instead, which keeps only the path and thus does not use an
+    /// open file descriptor for each file.
+    ///
     /// The `uid` and `gid` in `header` are added to FilesystemWriters id's
     pub fn push_file<P>(
         &mut self,
@@ -294,6 +298,29 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
     {
         let reader = Arc::new(Mutex::new(reader));
         let new_file = InnerNode::File(SquashfsFileWriter::UserDefined(reader));
+        self.insert_node(path, header, new_file)?;
+        Ok(())
+    }
+
+    /// Insert the file at `source` into filesystem with `path` and metadata `header`.
+    ///
+    /// The file is opened when [`Self::write`] is called, not now. Use this instead of
+    /// [`Self::push_file`] for files on disk: [`Self::push_file`] holds the reader, and thus an
+    /// open file descriptor, until the write. The `source` file must still exist at the time of
+    /// the write.
+    ///
+    /// The `uid` and `gid` in `header` are added to FilesystemWriters id's
+    pub fn push_file_from_path<S, P>(
+        &mut self,
+        source: S,
+        path: P,
+        header: NodeHeader,
+    ) -> Result<(), BackhandError>
+    where
+        S: Into<PathBuf>,
+        P: AsRef<Path>,
+    {
+        let new_file = InnerNode::File(SquashfsFileWriter::LazyFile(LazyFile::new(source)));
         self.insert_node(path, header, new_file)?;
         Ok(())
     }
@@ -320,6 +347,23 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
         let file = self.mut_file(find_path).ok_or(BackhandError::FileNotFound)?;
         let reader = Arc::new(Mutex::new(reader));
         *file = SquashfsFileWriter::UserDefined(reader);
+        Ok(())
+    }
+
+    /// Replace an existing file with the file at `source`, which is opened at write time
+    ///
+    /// See [`Self::push_file_from_path`].
+    pub fn replace_file_from_path<S, P>(
+        &mut self,
+        find_path: S,
+        source: P,
+    ) -> Result<(), BackhandError>
+    where
+        S: AsRef<Path>,
+        P: Into<PathBuf>,
+    {
+        let file = self.mut_file(find_path).ok_or(BackhandError::FileNotFound)?;
+        *file = SquashfsFileWriter::LazyFile(LazyFile::new(source));
         Ok(())
     }
 
@@ -476,6 +520,11 @@ impl<'a, 'b, 'c> FilesystemWriter<'a, 'b, 'c> {
                     let mut file_lock =
                         file_ptr.lock().map_err(|_| BackhandError::MutexPoisoned)?;
                     data_writer.add_bytes(&mut *file_lock, &mut writer)?
+                }
+                SquashfsFileWriter::LazyFile(lazy) => {
+                    // the file descriptor lives only for this file, not for the whole write
+                    let mut reader = lazy.open()?;
+                    data_writer.add_bytes(&mut reader, &mut writer)?
                 }
                 SquashfsFileWriter::SquashfsFile(file) => {
                     // if the source file and the destination files are both


### PR DESCRIPTION
Add two functions to facilitate creating images above the normal fd limits of a system:
- fs.push_file_from_path(source_path, "path/in/image", header)?;
- fs.replace_file_from_path("path/in/image", source_path)?;